### PR TITLE
Prevent Session Replays

### DIFF
--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -48,7 +48,7 @@
     "jest": "^26.6.3",
     "jest-when": "^3.3.0",
     "nodemon": "^2.0.7",
-    "prettier": "2.3.0",
+    "prettier": "^2.3.0",
     "rimraf": "^3.0.2",
     "supertest": "^6.1.3",
     "testdouble": "^3.16.1",

--- a/packages/back-end/src/challenge/challenge.router.spec.ts
+++ b/packages/back-end/src/challenge/challenge.router.spec.ts
@@ -6,11 +6,11 @@ import { ChallengeRouter } from "./challenge.router";
 import { ChallengeService } from "./challenge.service";
 import { object, when } from "testdouble";
 import { SessionPayload } from "../session/session-payload";
-import { generateRandomNumber, generateRandomString } from "../random";
 import { Challenge } from "./challenge";
 import { generateMockDraft } from "../draft/draft.mock";
 import { DraftService } from "../draft/draft.service";
 import { generateMockChallengeDto } from "./challenge.mock";
+import { generateMockSessionPayload } from "../session/session.mock";
 
 describe("Challenge Router (integration)", () => {
   let app: Application;
@@ -25,10 +25,7 @@ describe("Challenge Router (integration)", () => {
     challengeService = object<ChallengeService>();
     draftService = object<DraftService>();
     const router = new ChallengeRouter(challengeService, draftService);
-    session = {
-      userId: generateRandomNumber(),
-      accessKey: generateRandomString(),
-    };
+    session = generateMockSessionPayload()
     app.use((ctx, next) => {
       ctx.state.session = session;
       void next();

--- a/packages/back-end/src/challenge/challenge.router.spec.ts
+++ b/packages/back-end/src/challenge/challenge.router.spec.ts
@@ -25,7 +25,7 @@ describe("Challenge Router (integration)", () => {
     challengeService = object<ChallengeService>();
     draftService = object<DraftService>();
     const router = new ChallengeRouter(challengeService, draftService);
-    session = generateMockSessionPayload()
+    session = generateMockSessionPayload();
     app.use((ctx, next) => {
       ctx.state.session = session;
       void next();

--- a/packages/back-end/src/session/jwt-session.service.spec.ts
+++ b/packages/back-end/src/session/jwt-session.service.spec.ts
@@ -111,6 +111,28 @@ describe("JwtSessionService", () => {
       );
     });
 
+    it('throws an error if a given user fingerprint is invalid (claims side)', () => {
+      const { userFingerprint, userFingerprintHash } = getUserFingerprint()
+      const payload = {
+        id: generateRandomNumber(),
+        accessKey: generateRandomString(),
+        userFingerprint: userFingerprintHash + 'a'
+      };
+      const accessToken = jwt.sign(payload, accessTokenSecret);
+      expect(() => jwtSessionService.verifyOne(accessToken, userFingerprint)).toThrowError()
+    })
+
+    it('throws an error if a given user fingerprint is invalid (provided side)', () => {
+      const { userFingerprint, userFingerprintHash } = getUserFingerprint()
+      const payload = {
+        id: generateRandomNumber(),
+        accessKey: generateRandomString(),
+        userFingerprint: userFingerprintHash
+      };
+      const accessToken = jwt.sign(payload, accessTokenSecret);
+      expect(() => jwtSessionService.verifyOne(accessToken, userFingerprint + 'a')).toThrowError()
+    })
+
     it.each(["", null, undefined, "totes not a valid JWT token"])(
       "throws an error if a given access token is %p",
       (accessToken) => {

--- a/packages/back-end/src/session/jwt-session.service.spec.ts
+++ b/packages/back-end/src/session/jwt-session.service.spec.ts
@@ -9,7 +9,7 @@ import jwt from "jsonwebtoken";
 import { RefreshPayload } from "./refresh-payload";
 import { User } from "../user/user";
 import { Logger } from "pino";
-import { v4 as uuid } from 'uuid'
+import { v4 as uuid } from "uuid";
 import { randomBytes, createHash } from "crypto";
 
 describe("JwtSessionService", () => {
@@ -85,20 +85,22 @@ describe("JwtSessionService", () => {
 
   describe("verifyOne", () => {
     const getUserFingerprint = () => {
-      const userFingerprint = randomBytes(50).toString('hex')
-      const userFingerprintHash = createHash('sha256').update(userFingerprint).digest('hex')
+      const userFingerprint = randomBytes(50).toString("hex");
+      const userFingerprintHash = createHash("sha256")
+        .update(userFingerprint)
+        .digest("hex");
       return {
         userFingerprint,
-        userFingerprintHash
-      }
-    }
+        userFingerprintHash,
+      };
+    };
 
     it("returns the decoded payload if the given access token is valid", () => {
-      const { userFingerprint, userFingerprintHash } = getUserFingerprint()
+      const { userFingerprint, userFingerprintHash } = getUserFingerprint();
       const payload = {
         id: generateRandomNumber(),
         accessKey: generateRandomString(),
-        userFingerprint: userFingerprintHash
+        userFingerprint: userFingerprintHash,
       };
       const accessToken = jwt.sign(payload, accessTokenSecret);
       expect(jwtSessionService.verifyOne(accessToken, userFingerprint)).toEqual(
@@ -111,27 +113,31 @@ describe("JwtSessionService", () => {
       );
     });
 
-    it('throws an error if a given user fingerprint is invalid (claims side)', () => {
-      const { userFingerprint, userFingerprintHash } = getUserFingerprint()
+    it("throws an error if a given user fingerprint is invalid (claims side)", () => {
+      const { userFingerprint, userFingerprintHash } = getUserFingerprint();
       const payload = {
         id: generateRandomNumber(),
         accessKey: generateRandomString(),
-        userFingerprint: userFingerprintHash + 'a'
+        userFingerprint: userFingerprintHash + "a",
       };
       const accessToken = jwt.sign(payload, accessTokenSecret);
-      expect(() => jwtSessionService.verifyOne(accessToken, userFingerprint)).toThrowError()
-    })
+      expect(() =>
+        jwtSessionService.verifyOne(accessToken, userFingerprint)
+      ).toThrowError();
+    });
 
-    it('throws an error if a given user fingerprint is invalid (provided side)', () => {
-      const { userFingerprint, userFingerprintHash } = getUserFingerprint()
+    it("throws an error if a given user fingerprint is invalid (provided side)", () => {
+      const { userFingerprint, userFingerprintHash } = getUserFingerprint();
       const payload = {
         id: generateRandomNumber(),
         accessKey: generateRandomString(),
-        userFingerprint: userFingerprintHash
+        userFingerprint: userFingerprintHash,
       };
       const accessToken = jwt.sign(payload, accessTokenSecret);
-      expect(() => jwtSessionService.verifyOne(accessToken, userFingerprint + 'a')).toThrowError()
-    })
+      expect(() =>
+        jwtSessionService.verifyOne(accessToken, userFingerprint + "a")
+      ).toThrowError();
+    });
 
     it.each(["", null, undefined, "totes not a valid JWT token"])(
       "throws an error if a given access token is %p",
@@ -148,7 +154,7 @@ describe("JwtSessionService", () => {
         const payload = {
           id: generateRandomNumber(),
           accessKey: generateRandomString(),
-          userFingerprint: uuid()
+          userFingerprint: uuid(),
         };
         const accessToken = jwt.sign(payload, accessTokenSecret);
         expect(() =>
@@ -159,7 +165,9 @@ describe("JwtSessionService", () => {
 
     it("throws an error if a given access token was signed with an incorrect secret", () => {
       const accessToken = jwt.sign({}, "totes not the expected JWT secret");
-      expect(() => jwtSessionService.verifyOne(accessToken, uuid())).toThrowError();
+      expect(() =>
+        jwtSessionService.verifyOne(accessToken, uuid())
+      ).toThrowError();
     });
   });
 

--- a/packages/back-end/src/session/jwt-session.service.spec.ts
+++ b/packages/back-end/src/session/jwt-session.service.spec.ts
@@ -9,6 +9,7 @@ import jwt from "jsonwebtoken";
 import { RefreshPayload } from "./refresh-payload";
 import { User } from "../user/user";
 import { Logger } from "pino";
+import { v4 as uuid } from 'uuid'
 
 describe("JwtSessionService", () => {
   let jwtSessionService: JwtSessionService;
@@ -87,8 +88,9 @@ describe("JwtSessionService", () => {
         id: generateRandomNumber(),
         accessKey: generateRandomString(),
       };
+      const userFingerprint = uuid()
       const accessToken = jwt.sign(payload, accessTokenSecret);
-      expect(jwtSessionService.verifyOne(accessToken)).toEqual(
+      expect(jwtSessionService.verifyOne(accessToken, userFingerprint)).toEqual(
         expect.objectContaining({
           id: payload.id,
           accessKey: payload.accessKey,
@@ -102,14 +104,14 @@ describe("JwtSessionService", () => {
       "throws an error if a given access token is %p",
       (accessToken) => {
         expect(() =>
-          jwtSessionService.verifyOne(accessToken as string)
+          jwtSessionService.verifyOne(accessToken as string, uuid())
         ).toThrowError();
       }
     );
 
     it("throws an error if a given access token was signed with an incorrect secret", () => {
       const accessToken = jwt.sign({}, "totes not the expected JWT secret");
-      expect(() => jwtSessionService.verifyOne(accessToken)).toThrowError();
+      expect(() => jwtSessionService.verifyOne(accessToken, uuid())).toThrowError();
     });
   });
 

--- a/packages/back-end/src/session/jwt-session.service.ts
+++ b/packages/back-end/src/session/jwt-session.service.ts
@@ -108,4 +108,8 @@ export class JwtSessionService implements SessionService {
     ) as JsonWebTokenPayload;
     return new Session(accessToken, refreshToken, accessTokenExpiration);
   }
+
+  private createFingerprintForSession(): string {
+    return ''
+  }
 }

--- a/packages/back-end/src/session/jwt-session.service.ts
+++ b/packages/back-end/src/session/jwt-session.service.ts
@@ -48,12 +48,23 @@ export class JwtSessionService implements SessionService {
     return this.signTokensForUser(associatedUser);
   }
 
-  verifyOne(accessToken: string, providedUserFingerprint: string): SessionPayload {
-    const claims = jwt.verify(accessToken, this.accessTokenSecret) as SessionPayload;
+  verifyOne(
+    accessToken: string,
+    providedUserFingerprint: string
+  ): SessionPayload {
+    const claims = jwt.verify(
+      accessToken,
+      this.accessTokenSecret
+    ) as SessionPayload;
 
-    if (this.hashUserFingerprint(providedUserFingerprint) !== claims.userFingerprint) {
-      this.logger.error(`A possible malicious attempt to verify a token happened for user with id = ${claims.userId} . The fingerprint was deemed invalid.`)
-      throw new Error('Invalid Login Information')
+    if (
+      this.hashUserFingerprint(providedUserFingerprint) !==
+      claims.userFingerprint
+    ) {
+      this.logger.error(
+        `A possible malicious attempt to verify a token happened for user with id = ${claims.userId} . The fingerprint was deemed invalid.`
+      );
+      throw new Error("Invalid Login Information");
     }
 
     return claims;
@@ -90,13 +101,13 @@ export class JwtSessionService implements SessionService {
   }
 
   private signTokensForUser(user: User): Session {
-    const fingerprint = this.createUserFingerprint()
+    const fingerprint = this.createUserFingerprint();
 
     const accessToken = jwt.sign(
-      { 
-        userId: user.id, 
-        accessKey: user.accessKey ,
-        userFingerprint: this.hashUserFingerprint(fingerprint)
+      {
+        userId: user.id,
+        accessKey: user.accessKey,
+        userFingerprint: this.hashUserFingerprint(fingerprint),
       },
       this.accessTokenSecret,
       {
@@ -120,15 +131,20 @@ export class JwtSessionService implements SessionService {
       accessToken,
       this.accessTokenSecret
     ) as JsonWebTokenPayload;
-    return new Session(accessToken, refreshToken, accessTokenExpiration, fingerprint);
+    return new Session(
+      accessToken,
+      refreshToken,
+      accessTokenExpiration,
+      fingerprint
+    );
   }
 
   private createUserFingerprint(): string {
-    const randomFingerprint = randomBytes(50)
-    return randomFingerprint.toString('hex')
+    const randomFingerprint = randomBytes(50);
+    return randomFingerprint.toString("hex");
   }
 
   private hashUserFingerprint(fingerprint: string): string {
-    return createHash('sha256').update(fingerprint).digest('hex')
+    return createHash("sha256").update(fingerprint).digest("hex");
   }
 }

--- a/packages/back-end/src/session/jwt-session.service.ts
+++ b/packages/back-end/src/session/jwt-session.service.ts
@@ -48,8 +48,15 @@ export class JwtSessionService implements SessionService {
     return this.signTokensForUser(associatedUser);
   }
 
-  verifyOne(accessToken: string): SessionPayload {
-    return jwt.verify(accessToken, this.accessTokenSecret) as SessionPayload;
+  verifyOne(accessToken: string, providedUserFingerprint: string): SessionPayload {
+    const claims = jwt.verify(accessToken, this.accessTokenSecret) as SessionPayload;
+
+    if (this.hashUserFingerprint(providedUserFingerprint) !== claims.userFingerprint) {
+      this.logger.error(`A possible malicious attempt to verify a token happened for user with id = ${claims.userId} . The fingerprint was deemed invalid.`)
+      throw new Error('Invalid Login Information')
+    }
+
+    return claims;
   }
 
   async refreshOne(refreshToken: string): Promise<Session> {

--- a/packages/back-end/src/session/session-payload.ts
+++ b/packages/back-end/src/session/session-payload.ts
@@ -1,4 +1,5 @@
 export interface SessionPayload {
   readonly userId: number;
   readonly accessKey: string;
+  readonly userFingerprint: string;
 }

--- a/packages/back-end/src/session/session.middleware.spec.ts
+++ b/packages/back-end/src/session/session.middleware.spec.ts
@@ -7,7 +7,7 @@ import { generateRandomNumber, generateRandomString } from "../random";
 import { SessionPayload } from "./session-payload";
 import { ContextState } from "../types/state";
 import { USER_FINGERPRINT_COOKIE_KEY } from "./session.router";
-import { v4 as uuid } from 'uuid'
+import { v4 as uuid } from "uuid";
 
 describe("sessionMiddleware", () => {
   let sessionService: SessionService;
@@ -34,30 +34,39 @@ describe("sessionMiddleware", () => {
     expect(mockNext).not.toHaveBeenCalled();
   });
 
-  it.each(['', undefined])("throws error if user fingerprint cookie provided is %p", async (userFingerprint?: string) => {
-    const mockCtx = object<ParameterizedContext<ContextState>>();
-    when(mockCtx.cookies.get(USER_FINGERPRINT_COOKIE_KEY)).thenReturn(userFingerprint)
-    const mockNext = jest.fn();
-    mockCtx.header = {
-      authorization: undefined,
-    };
-    await expect(
-      sessionMiddlewareToTest(mockCtx, mockNext)
-    ).rejects.toThrowError();
-    expect(mockCtx.status).toEqual(UNAUTHORIZED);
-    expect(mockNext).not.toHaveBeenCalled();
-  });
+  it.each(["", undefined])(
+    "throws error if user fingerprint cookie provided is %p",
+    async (userFingerprint?: string) => {
+      const mockCtx = object<ParameterizedContext<ContextState>>();
+      when(mockCtx.cookies.get(USER_FINGERPRINT_COOKIE_KEY)).thenReturn(
+        userFingerprint
+      );
+      const mockNext = jest.fn();
+      mockCtx.header = {
+        authorization: undefined,
+      };
+      await expect(
+        sessionMiddlewareToTest(mockCtx, mockNext)
+      ).rejects.toThrowError();
+      expect(mockCtx.status).toEqual(UNAUTHORIZED);
+      expect(mockNext).not.toHaveBeenCalled();
+    }
+  );
 
   it("throws an error if the access token provided is invalid", async () => {
     const mockCtx = object<ParameterizedContext<ContextState>>();
-    const userFingerprint = uuid()
-    when(mockCtx.cookies.get(USER_FINGERPRINT_COOKIE_KEY)).thenReturn(userFingerprint)
+    const userFingerprint = uuid();
+    when(mockCtx.cookies.get(USER_FINGERPRINT_COOKIE_KEY)).thenReturn(
+      userFingerprint
+    );
     const mockNext = jest.fn();
     const authorization = "some-invalid-token";
     mockCtx.header = {
       authorization,
     };
-    when(sessionService.verifyOne(authorization, userFingerprint)).thenThrow(new Error());
+    when(sessionService.verifyOne(authorization, userFingerprint)).thenThrow(
+      new Error()
+    );
     await expect(
       sessionMiddlewareToTest(mockCtx, mockNext)
     ).rejects.toThrowError();
@@ -67,8 +76,10 @@ describe("sessionMiddleware", () => {
 
   it("resumes and goes through the middleware if the access token provided is valid", async () => {
     const mockCtx = object<ParameterizedContext<ContextState>>();
-    const userFingerprint = uuid()
-    when(mockCtx.cookies.get(USER_FINGERPRINT_COOKIE_KEY)).thenReturn(userFingerprint)
+    const userFingerprint = uuid();
+    when(mockCtx.cookies.get(USER_FINGERPRINT_COOKIE_KEY)).thenReturn(
+      userFingerprint
+    );
     const mockNext = jest.fn();
     const authorization = "some-invalid-token";
     mockCtx.status = OK;
@@ -78,9 +89,11 @@ describe("sessionMiddleware", () => {
     const sessionPayload: SessionPayload = {
       userId: generateRandomNumber(),
       accessKey: generateRandomString(),
-      userFingerprint
+      userFingerprint,
     };
-    when(sessionService.verifyOne(authorization, userFingerprint)).thenReturn(sessionPayload);
+    when(sessionService.verifyOne(authorization, userFingerprint)).thenReturn(
+      sessionPayload
+    );
     await expect(
       sessionMiddlewareToTest(mockCtx, mockNext)
     ).resolves.not.toThrowError();

--- a/packages/back-end/src/session/session.middleware.spec.ts
+++ b/packages/back-end/src/session/session.middleware.spec.ts
@@ -6,6 +6,8 @@ import { FORBIDDEN, OK, UNAUTHORIZED } from "http-status";
 import { generateRandomNumber, generateRandomString } from "../random";
 import { SessionPayload } from "./session-payload";
 import { ContextState } from "../types/state";
+import { USER_FINGERPRINT_COOKIE_KEY } from "./session.router";
+import { v4 as uuid } from 'uuid'
 
 describe("sessionMiddleware", () => {
   let sessionService: SessionService;
@@ -32,14 +34,30 @@ describe("sessionMiddleware", () => {
     expect(mockNext).not.toHaveBeenCalled();
   });
 
+  it.each(['', undefined])("throws error if user fingerprint cookie provided is %p", async (userFingerprint?: string) => {
+    const mockCtx = object<ParameterizedContext<ContextState>>();
+    when(mockCtx.cookies.get(USER_FINGERPRINT_COOKIE_KEY)).thenReturn(userFingerprint)
+    const mockNext = jest.fn();
+    mockCtx.header = {
+      authorization: undefined,
+    };
+    await expect(
+      sessionMiddlewareToTest(mockCtx, mockNext)
+    ).rejects.toThrowError();
+    expect(mockCtx.status).toEqual(UNAUTHORIZED);
+    expect(mockNext).not.toHaveBeenCalled();
+  });
+
   it("throws an error if the access token provided is invalid", async () => {
     const mockCtx = object<ParameterizedContext<ContextState>>();
+    const userFingerprint = uuid()
+    when(mockCtx.cookies.get(USER_FINGERPRINT_COOKIE_KEY)).thenReturn(userFingerprint)
     const mockNext = jest.fn();
     const authorization = "some-invalid-token";
     mockCtx.header = {
       authorization,
     };
-    when(sessionService.verifyOne(authorization)).thenThrow(new Error());
+    when(sessionService.verifyOne(authorization, userFingerprint)).thenThrow(new Error());
     await expect(
       sessionMiddlewareToTest(mockCtx, mockNext)
     ).rejects.toThrowError();
@@ -49,6 +67,8 @@ describe("sessionMiddleware", () => {
 
   it("resumes and goes through the middleware if the access token provided is valid", async () => {
     const mockCtx = object<ParameterizedContext<ContextState>>();
+    const userFingerprint = uuid()
+    when(mockCtx.cookies.get(USER_FINGERPRINT_COOKIE_KEY)).thenReturn(userFingerprint)
     const mockNext = jest.fn();
     const authorization = "some-invalid-token";
     mockCtx.status = OK;
@@ -58,8 +78,9 @@ describe("sessionMiddleware", () => {
     const sessionPayload: SessionPayload = {
       userId: generateRandomNumber(),
       accessKey: generateRandomString(),
+      userFingerprint
     };
-    when(sessionService.verifyOne(authorization)).thenReturn(sessionPayload);
+    when(sessionService.verifyOne(authorization, userFingerprint)).thenReturn(sessionPayload);
     await expect(
       sessionMiddlewareToTest(mockCtx, mockNext)
     ).resolves.not.toThrowError();

--- a/packages/back-end/src/session/session.middleware.ts
+++ b/packages/back-end/src/session/session.middleware.ts
@@ -2,6 +2,7 @@ import { Next, ParameterizedContext } from "koa";
 import { SessionService } from "./session.service";
 import { UNAUTHORIZED, FORBIDDEN } from "http-status";
 import { ContextState } from "../types/state";
+import { USER_FINGERPRINT_COOKIE_KEY } from "./session.router";
 
 export const sessionMiddleware =
   (sessionService: SessionService) =>
@@ -9,13 +10,14 @@ export const sessionMiddleware =
     ctx: ParameterizedContext<ContextState>,
     next: Next
   ): Promise<void> => {
-    if (!ctx.header.authorization) {
+    const userFingerprint = ctx.cookies.get(USER_FINGERPRINT_COOKIE_KEY)
+    if (!ctx.header.authorization || !userFingerprint) {
       ctx.status = UNAUTHORIZED;
       throw new Error("Authentication must be provided.");
     }
 
     try {
-      const session = sessionService.verifyOne(ctx.header.authorization);
+      const session = sessionService.verifyOne(ctx.header.authorization, userFingerprint);
       ctx.state.session = session;
     } catch (error) {
       ctx.status = FORBIDDEN;

--- a/packages/back-end/src/session/session.middleware.ts
+++ b/packages/back-end/src/session/session.middleware.ts
@@ -10,14 +10,17 @@ export const sessionMiddleware =
     ctx: ParameterizedContext<ContextState>,
     next: Next
   ): Promise<void> => {
-    const userFingerprint = ctx.cookies.get(USER_FINGERPRINT_COOKIE_KEY)
+    const userFingerprint = ctx.cookies.get(USER_FINGERPRINT_COOKIE_KEY);
     if (!ctx.header.authorization || !userFingerprint) {
       ctx.status = UNAUTHORIZED;
       throw new Error("Authentication must be provided.");
     }
 
     try {
-      const session = sessionService.verifyOne(ctx.header.authorization, userFingerprint);
+      const session = sessionService.verifyOne(
+        ctx.header.authorization,
+        userFingerprint
+      );
       ctx.state.session = session;
     } catch (error) {
       ctx.status = FORBIDDEN;

--- a/packages/back-end/src/session/session.mock.ts
+++ b/packages/back-end/src/session/session.mock.ts
@@ -1,0 +1,12 @@
+
+import { generateRandomNumber, generateRandomString } from "../random";
+import { Session } from "./session";
+
+export const generateMockSession = (): Session => {
+  return new Session(
+    generateRandomString(),
+    generateRandomString(),
+    generateRandomNumber(),
+    generateRandomString()
+  );
+}

--- a/packages/back-end/src/session/session.mock.ts
+++ b/packages/back-end/src/session/session.mock.ts
@@ -1,4 +1,3 @@
-
 import { generateRandomNumber, generateRandomString } from "../random";
 import { Session } from "./session";
 import { SessionPayload } from "./session-payload";
@@ -10,12 +9,12 @@ export const generateMockSession = (): Session => {
     generateRandomNumber(),
     generateRandomString()
   );
-}
+};
 
 export const generateMockSessionPayload = (): SessionPayload => {
   return {
-      userId: generateRandomNumber(),
-      accessKey: generateRandomString(),
-      userFingerprint: generateRandomString()
-  }
-}
+    userId: generateRandomNumber(),
+    accessKey: generateRandomString(),
+    userFingerprint: generateRandomString(),
+  };
+};

--- a/packages/back-end/src/session/session.mock.ts
+++ b/packages/back-end/src/session/session.mock.ts
@@ -1,6 +1,7 @@
 
 import { generateRandomNumber, generateRandomString } from "../random";
 import { Session } from "./session";
+import { SessionPayload } from "./session-payload";
 
 export const generateMockSession = (): Session => {
   return new Session(
@@ -9,4 +10,12 @@ export const generateMockSession = (): Session => {
     generateRandomNumber(),
     generateRandomString()
   );
+}
+
+export const generateMockSessionPayload = (): SessionPayload => {
+  return {
+      userId: generateRandomNumber(),
+      accessKey: generateRandomString(),
+      userFingerprint: generateRandomString()
+  }
 }

--- a/packages/back-end/src/session/session.router.spec.ts
+++ b/packages/back-end/src/session/session.router.spec.ts
@@ -123,11 +123,13 @@ describe("Session Router (integration)", () => {
       expect(response.status).toEqual(NO_CONTENT);
     });
 
-    it("returns with the refresh token set to be nulled", async () => {
+    it("returns with the refresh token and user fingerprint set to be nulled", async () => {
       const response = await request.delete(uri).send();
-      const [refreshTokenCookie] = response.headers["set-cookie"];
+      const [refreshTokenCookie, userFingerprintCookie] = response.headers["set-cookie"];
       expect(refreshTokenCookie).toContain(`${REFRESH_TOKEN_COOKIE_KEY}=;`);
       expect(refreshTokenCookie).toContain("httponly");
+      expect(userFingerprintCookie).toContain(`${USER_FINGERPRINT_COOKIE_KEY}=;`);
+      expect(userFingerprintCookie).toContain("httponly");
     });
   });
 });

--- a/packages/back-end/src/session/session.router.spec.ts
+++ b/packages/back-end/src/session/session.router.spec.ts
@@ -6,7 +6,11 @@ import bodyParser from "koa-bodyparser";
 import { Server } from "http";
 import supertest from "supertest";
 import { object, when } from "testdouble";
-import { REFRESH_TOKEN_COOKIE_KEY, SessionRouter, USER_FINGERPRINT_COOKIE_KEY } from "./session.router";
+import {
+  REFRESH_TOKEN_COOKIE_KEY,
+  SessionRouter,
+  USER_FINGERPRINT_COOKIE_KEY,
+} from "./session.router";
 import { SessionService } from "./session.service";
 import { CREATED, FORBIDDEN, NO_CONTENT } from "http-status";
 import { generateRandomString } from "../random";
@@ -42,7 +46,7 @@ describe("Session Router (integration)", () => {
         accessKey: generateRandomString(),
         password: generateRandomString(),
       };
-      const tokenPayload = generateMockSession()
+      const tokenPayload = generateMockSession();
       when(sessionService.createOne(createSessionRequest)).thenResolve(
         tokenPayload
       );
@@ -55,17 +59,18 @@ describe("Session Router (integration)", () => {
         accessKey: generateRandomString(),
         password: generateRandomString(),
       };
-      const expected = generateMockSession()
+      const expected = generateMockSession();
       when(sessionService.createOne(createSessionRequest)).thenResolve(
         expected
       );
       const response = await request.post(uri).send(createSessionRequest);
       expect(response.body).toEqual(expected.toJSON());
       expect(response.body.refreshToken).toBeFalsy();
-      const [refreshTokenCookie, userFingerprintCookie] = response.headers["set-cookie"];
+      const [refreshTokenCookie, userFingerprintCookie] =
+        response.headers["set-cookie"];
       expect(refreshTokenCookie).toContain(REFRESH_TOKEN_COOKIE_KEY);
       expect(refreshTokenCookie).toContain("httponly");
-      expect(userFingerprintCookie).toContain(USER_FINGERPRINT_COOKIE_KEY)
+      expect(userFingerprintCookie).toContain(USER_FINGERPRINT_COOKIE_KEY);
       expect(userFingerprintCookie).toContain("httponly");
     });
   });
@@ -75,7 +80,7 @@ describe("Session Router (integration)", () => {
 
     it("returns with 201 CREATED status", async () => {
       const refreshToken = generateRandomString();
-      const tokenPayload = generateMockSession()
+      const tokenPayload = generateMockSession();
       when(sessionService.refreshOne(refreshToken)).thenResolve(tokenPayload);
       const httpRequest = request.put(uri);
       await httpRequest.set("Cookie", [
@@ -88,7 +93,7 @@ describe("Session Router (integration)", () => {
 
     it("returns with 403 FORBIDDEN status if no cookie is provided", async () => {
       const refreshToken = generateRandomString();
-      const tokenPayload = generateMockSession()
+      const tokenPayload = generateMockSession();
       when(sessionService.refreshOne(refreshToken)).thenResolve(tokenPayload);
       const httpRequest = request.put(uri);
       const response = await httpRequest.send();
@@ -98,7 +103,7 @@ describe("Session Router (integration)", () => {
 
     it("returns with the session as the response", async () => {
       const refreshToken = generateRandomString();
-      const tokenPayload = generateMockSession()
+      const tokenPayload = generateMockSession();
       when(sessionService.refreshOne(refreshToken)).thenResolve(tokenPayload);
       const httpRequest = request.put(uri);
       await httpRequest.set("Cookie", [
@@ -107,10 +112,11 @@ describe("Session Router (integration)", () => {
       const response = await httpRequest.send();
       expect(response.body).toEqual(tokenPayload.toJSON());
       expect(response.body.refreshToken).toBeFalsy();
-      const [refreshTokenCookie, userFingerprintCookie] = response.headers["set-cookie"];
+      const [refreshTokenCookie, userFingerprintCookie] =
+        response.headers["set-cookie"];
       expect(refreshTokenCookie).toContain(REFRESH_TOKEN_COOKIE_KEY);
       expect(refreshTokenCookie).toContain("httponly");
-      expect(userFingerprintCookie).toContain(USER_FINGERPRINT_COOKIE_KEY)
+      expect(userFingerprintCookie).toContain(USER_FINGERPRINT_COOKIE_KEY);
       expect(userFingerprintCookie).toContain("httponly");
     });
   });
@@ -125,10 +131,13 @@ describe("Session Router (integration)", () => {
 
     it("returns with the refresh token and user fingerprint set to be nulled", async () => {
       const response = await request.delete(uri).send();
-      const [refreshTokenCookie, userFingerprintCookie] = response.headers["set-cookie"];
+      const [refreshTokenCookie, userFingerprintCookie] =
+        response.headers["set-cookie"];
       expect(refreshTokenCookie).toContain(`${REFRESH_TOKEN_COOKIE_KEY}=;`);
       expect(refreshTokenCookie).toContain("httponly");
-      expect(userFingerprintCookie).toContain(`${USER_FINGERPRINT_COOKIE_KEY}=;`);
+      expect(userFingerprintCookie).toContain(
+        `${USER_FINGERPRINT_COOKIE_KEY}=;`
+      );
       expect(userFingerprintCookie).toContain("httponly");
     });
   });

--- a/packages/back-end/src/session/session.router.ts
+++ b/packages/back-end/src/session/session.router.ts
@@ -41,7 +41,7 @@ export class SessionRouter extends Router {
 
     this.delete(this.CURRENT_SESSION_URI, (ctx) => {
       this.setRefreshTokenCookie(ctx, new Date(), null);
-      this.setUserFingerprintCookie(ctx, null)
+      this.setUserFingerprintCookie(ctx, null);
       ctx.status = NO_CONTENT;
     });
   }
@@ -77,7 +77,7 @@ export class SessionRouter extends Router {
   ): void {
     ctx.cookies.set(USER_FINGERPRINT_COOKIE_KEY, userFingerprint, {
       httpOnly: true,
-      secure: isProduction()
-    })
+      secure: isProduction(),
+    });
   }
 }

--- a/packages/back-end/src/session/session.router.ts
+++ b/packages/back-end/src/session/session.router.ts
@@ -76,7 +76,6 @@ export class SessionRouter extends Router {
   ): void {
     ctx.cookies.set(USER_FINGERPRINT_COOKIE_KEY, userFingerprint, {
       httpOnly: true,
-      path: this.URI,
       secure: isProduction()
     })
   }

--- a/packages/back-end/src/session/session.router.ts
+++ b/packages/back-end/src/session/session.router.ts
@@ -7,6 +7,7 @@ import { ParameterizedContext } from "koa";
 import { Session } from "./session";
 
 export const REFRESH_TOKEN_COOKIE_KEY = "ninjask_refresh-token";
+export const USER_FINGERPRINT_COOKIE_KEY = "ninjask_user-fingerprint";
 
 export class SessionRouter extends Router {
   private readonly URI = "/sessions";
@@ -53,6 +54,7 @@ export class SessionRouter extends Router {
     expires.setDate(expires.getDate() + 1);
     ctx.status = CREATED;
     this.setRefreshTokenCookie(ctx, expires, createdSession.refreshToken);
+    this.setUserFingerprintCookie(ctx, createdSession.userFingerprint);
   }
 
   private setRefreshTokenCookie(
@@ -66,5 +68,16 @@ export class SessionRouter extends Router {
       secure: isProduction(),
       expires,
     });
+  }
+
+  private setUserFingerprintCookie(
+    ctx: ParameterizedContext,
+    userFingerprint: string
+  ): void {
+    ctx.cookies.set(USER_FINGERPRINT_COOKIE_KEY, userFingerprint, {
+      httpOnly: true,
+      path: this.URI,
+      secure: isProduction()
+    })
   }
 }

--- a/packages/back-end/src/session/session.router.ts
+++ b/packages/back-end/src/session/session.router.ts
@@ -41,6 +41,7 @@ export class SessionRouter extends Router {
 
     this.delete(this.CURRENT_SESSION_URI, (ctx) => {
       this.setRefreshTokenCookie(ctx, new Date(), null);
+      this.setUserFingerprintCookie(ctx, null)
       ctx.status = NO_CONTENT;
     });
   }
@@ -72,7 +73,7 @@ export class SessionRouter extends Router {
 
   private setUserFingerprintCookie(
     ctx: ParameterizedContext,
-    userFingerprint: string
+    userFingerprint: string | null
   ): void {
     ctx.cookies.set(USER_FINGERPRINT_COOKIE_KEY, userFingerprint, {
       httpOnly: true,

--- a/packages/back-end/src/session/session.service.ts
+++ b/packages/back-end/src/session/session.service.ts
@@ -18,7 +18,10 @@ export interface SessionService {
    * @param providedUserFingerprint The user provided fingerprint to add an additional layer of verification.
    * @throws An error if the access token provided is invalid or the provided fingerprint is not valid.
    */
-  verifyOne(accessToken: string, providedUserFingerprint: string): SessionPayload;
+  verifyOne(
+    accessToken: string,
+    providedUserFingerprint: string
+  ): SessionPayload;
 
   /**
    * Refreshes an existing session by checking the validity of a given refresh token.

--- a/packages/back-end/src/session/session.service.ts
+++ b/packages/back-end/src/session/session.service.ts
@@ -15,9 +15,10 @@ export interface SessionService {
    * Verifies a given token and ensures that it is used for a legitamite session.
    *
    * @param token The access token to check.
-   * @throws An error if the access token provided is invalid.
+   * @param providedUserFingerprint The user provided fingerprint to add an additional layer of verification.
+   * @throws An error if the access token provided is invalid or the provided fingerprint is not valid.
    */
-  verifyOne(accessToken: string): SessionPayload;
+  verifyOne(accessToken: string, providedUserFingerprint: string): SessionPayload;
 
   /**
    * Refreshes an existing session by checking the validity of a given refresh token.

--- a/packages/back-end/src/session/session.ts
+++ b/packages/back-end/src/session/session.ts
@@ -7,7 +7,8 @@ export class Session {
   constructor(
     public readonly accessToken: string,
     public readonly refreshToken: string,
-    public readonly accessTokenExpiration: number
+    public readonly accessTokenExpiration: number,
+    public readonly userFingerprint: string
   ) {}
 
   toJSON(): JSONifiedSession {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12380,7 +12380,7 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@2.3.0, prettier@^2.3.0:
+prettier@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
   integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==


### PR DESCRIPTION
Using the technique documented in https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.html#token-sidejacking , the JWT access token is now more secure as we're using a HTTP Only cookie in conjunction with it. 

If a bad actor somehow got access to a token, they couldn't use it unless they also get access to the HTTP only cookie for a user fingerprint.