### PR TITLE
Add Unique Constraint for Challenge Result

### DIFF
--- a/packages/back-end/src/db/migrations/1621221959233-UniqueChallengeResults.ts
+++ b/packages/back-end/src/db/migrations/1621221959233-UniqueChallengeResults.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UniqueChallengeResults1621221959233 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE challenge_results ADD CONSTRAINT unique_user_challenge_results UNIQUE (challenge_id, user_id);
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE challenge_results DROP CONSTRAINT unique_user_challenge_results;
+        `);
+  }
+}


### PR DESCRIPTION
Prevent there being possible multiple results for a user and a given challenge. A user should only have one result for a given challenge.