### PR TITLE
Create Logic for Finalizing a Draft Selection Pick

### DIFF
--- a/packages/back-end/src/challenge-participant/challenge-participant.mock.ts
+++ b/packages/back-end/src/challenge-participant/challenge-participant.mock.ts
@@ -1,6 +1,7 @@
 import { ChallengeParticipantEntity } from "./challenge-participant.entity";
 import { ChallengeParticipant } from "./challenge-participant";
 import { generateRandomNumber } from "../random";
+import { generateMockUserEntity } from "../user/user.mock";
 
 export const generateMockChallengeParticipantEntity =
   (): ChallengeParticipantEntity => {
@@ -10,6 +11,7 @@ export const generateMockChallengeParticipantEntity =
     challengeResultEntity.challengeId = generateRandomNumber();
     challengeResultEntity.completionTimeHour = generateRandomNumber();
     challengeResultEntity.completionTimeMinutes = generateRandomNumber();
+    challengeResultEntity.user = Promise.resolve(generateMockUserEntity());
     return challengeResultEntity;
   };
 

--- a/packages/back-end/src/db/migrations/1623208726003-DraftSelectionIndexingOnRoundAndPickNumbers.ts
+++ b/packages/back-end/src/db/migrations/1623208726003-DraftSelectionIndexingOnRoundAndPickNumbers.ts
@@ -5,13 +5,15 @@ export class DraftSelectionIndexingOnRoundAndPickNumbers1623208726003
 {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
-            CREATE INDEX IF NOT EXISTS draft_selection_pokemon_idx ON draft_selection (pokemon_id);
+            CREATE INDEX IF NOT EXISTS draft_selection_round_idx ON draft_selection (round_number);
+            CREATE INDEX IF NOT EXISTS draft_selection_pick_idx ON draft_selection (pick_number);
         `);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
-            DROP INDEX IF EXISTS draft_selection_pokemon_idx;
+            DROP INDEX IF EXISTS draft_selection_round_idx;
+            DROP INDEX IF EXISTS draft_selection_pick_idx;
         `);
   }
 }

--- a/packages/back-end/src/db/migrations/1623208726003-DraftSelectionIndexingOnRoundAndPickNumbers.ts
+++ b/packages/back-end/src/db/migrations/1623208726003-DraftSelectionIndexingOnRoundAndPickNumbers.ts
@@ -1,0 +1,19 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class DraftSelectionIndexingOnRoundAndPickNumbers1623208726003 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE INDEX IF NOT EXISTS draft_selection_round_idx ON draft_selection (round_number);
+            CREATE INDEX IF NOT EXISTS draft_selection_pick_idx ON draft_selection (pick_number);
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP INDEX IF EXISTS draft_selection_round_idx;
+            DROP INDEX IF EXISTS draft_selection_pick_idx;
+        `)
+    }
+
+}

--- a/packages/back-end/src/db/migrations/1623208726003-DraftSelectionIndexingOnRoundAndPickNumbers.ts
+++ b/packages/back-end/src/db/migrations/1623208726003-DraftSelectionIndexingOnRoundAndPickNumbers.ts
@@ -5,15 +5,13 @@ export class DraftSelectionIndexingOnRoundAndPickNumbers1623208726003
 {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
-            CREATE INDEX IF NOT EXISTS draft_selection_round_idx ON draft_selection (round_number);
-            CREATE INDEX IF NOT EXISTS draft_selection_pick_idx ON draft_selection (pick_number);
+            CREATE INDEX IF NOT EXISTS draft_selection_pokemon_idx ON draft_selection (pokemon_id);
         `);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
-            DROP INDEX IF EXISTS draft_selection_round_idx;
-            DROP INDEX IF EXISTS draft_selection_pick_idx;
+            DROP INDEX IF EXISTS draft_selection_pokemon_idx;
         `);
   }
 }

--- a/packages/back-end/src/db/migrations/1623208726003-DraftSelectionIndexingOnRoundAndPickNumbers.ts
+++ b/packages/back-end/src/db/migrations/1623208726003-DraftSelectionIndexingOnRoundAndPickNumbers.ts
@@ -1,19 +1,19 @@
-import {MigrationInterface, QueryRunner} from "typeorm";
+import { MigrationInterface, QueryRunner } from "typeorm";
 
-export class DraftSelectionIndexingOnRoundAndPickNumbers1623208726003 implements MigrationInterface {
-
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`
+export class DraftSelectionIndexingOnRoundAndPickNumbers1623208726003
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
             CREATE INDEX IF NOT EXISTS draft_selection_round_idx ON draft_selection (round_number);
             CREATE INDEX IF NOT EXISTS draft_selection_pick_idx ON draft_selection (pick_number);
-        `)
-    }
+        `);
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
             DROP INDEX IF EXISTS draft_selection_round_idx;
             DROP INDEX IF EXISTS draft_selection_pick_idx;
-        `)
-    }
-
+        `);
+  }
 }

--- a/packages/back-end/src/db/migrations/1623212393244-TieDraftToSelections.ts
+++ b/packages/back-end/src/db/migrations/1623212393244-TieDraftToSelections.ts
@@ -1,0 +1,19 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class TieDraftToSelections1623212393244 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE IF EXISTS draft_selection ADD COLUMN IF NOT EXISTS draft_id INTEGER REFERENCES draft (id) NOT NULL;
+            ALTER TABLE draft_selection ADD CONSTRAINT unique_draft_selection UNIQUE (draft_id, round_number, pick_number);
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE IF EXISTS draft_selection DROP CONSTRAINT unique_draft_selection;
+            ALTER TABLE IF EXISTS draft_selection DROP COLUMN draft_id;
+        `)
+    }
+
+}

--- a/packages/back-end/src/db/migrations/1623212393244-TieDraftToSelections.ts
+++ b/packages/back-end/src/db/migrations/1623212393244-TieDraftToSelections.ts
@@ -1,19 +1,17 @@
-import {MigrationInterface, QueryRunner} from "typeorm";
+import { MigrationInterface, QueryRunner } from "typeorm";
 
 export class TieDraftToSelections1623212393244 implements MigrationInterface {
-
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
             ALTER TABLE IF EXISTS draft_selection ADD COLUMN IF NOT EXISTS draft_id INTEGER REFERENCES draft (id) NOT NULL;
             ALTER TABLE draft_selection ADD CONSTRAINT unique_draft_selection UNIQUE (draft_id, round_number, pick_number);
-        `)
-    }
+        `);
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
             ALTER TABLE IF EXISTS draft_selection DROP CONSTRAINT unique_draft_selection;
             ALTER TABLE IF EXISTS draft_selection DROP COLUMN draft_id;
-        `)
-    }
-
+        `);
+  }
 }

--- a/packages/back-end/src/db/migrations/1623215125411-CreateIndexForPokemonIdOnDraftSelection.ts
+++ b/packages/back-end/src/db/migrations/1623215125411-CreateIndexForPokemonIdOnDraftSelection.ts
@@ -1,0 +1,13 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class CreateIndexForPokemonIdOnDraftSelection1623215125411 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    }
+
+}

--- a/packages/back-end/src/db/migrations/1623215125411-CreateIndexForPokemonIdOnDraftSelection.ts
+++ b/packages/back-end/src/db/migrations/1623215125411-CreateIndexForPokemonIdOnDraftSelection.ts
@@ -6,11 +6,13 @@ export class CreateIndexForPokemonIdOnDraftSelection1623215125411
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
         CREATE INDEX IF NOT EXISTS draft_selection_pokemon_idx ON draft_selection (pokemon_id);
+        CREATE INDEX IF NOT EXISTS draft_selection_draft_idx ON draft_selection (draft_id);
     `);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
+        DROP INDEX IF EXISTS draft_selection_draft_idx;
         DROP INDEX IF EXISTS draft_selection_pokemon_idx;
     `);
   }

--- a/packages/back-end/src/db/migrations/1623215125411-CreateIndexForPokemonIdOnDraftSelection.ts
+++ b/packages/back-end/src/db/migrations/1623215125411-CreateIndexForPokemonIdOnDraftSelection.ts
@@ -5,8 +5,13 @@ export class CreateIndexForPokemonIdOnDraftSelection1623215125411
 {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
-        `);
+        CREATE INDEX IF NOT EXISTS draft_selection_pokemon_idx ON draft_selection (pokemon_id);
+    `);
   }
 
-  public async down(queryRunner: QueryRunner): Promise<void> {}
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        DROP INDEX IF EXISTS draft_selection_pokemon_idx;
+    `);
+  }
 }

--- a/packages/back-end/src/db/migrations/1623215125411-CreateIndexForPokemonIdOnDraftSelection.ts
+++ b/packages/back-end/src/db/migrations/1623215125411-CreateIndexForPokemonIdOnDraftSelection.ts
@@ -1,13 +1,12 @@
-import {MigrationInterface, QueryRunner} from "typeorm";
+import { MigrationInterface, QueryRunner } from "typeorm";
 
-export class CreateIndexForPokemonIdOnDraftSelection1623215125411 implements MigrationInterface {
+export class CreateIndexForPokemonIdOnDraftSelection1623215125411
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        `);
+  }
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`
-        `)
-    }
-
-    public async down(queryRunner: QueryRunner): Promise<void> {
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {}
 }

--- a/packages/back-end/src/draft-selection/draft-selection.entity.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.entity.ts
@@ -52,4 +52,7 @@ export class DraftSelectionEntity {
     name: "draft_id",
   })
   draft!: Promise<DraftEntity>;
+
+  @Column()
+  draftId!: number;
 }

--- a/packages/back-end/src/draft-selection/draft-selection.entity.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.entity.ts
@@ -8,6 +8,7 @@ import {
 } from "typeorm";
 import { ChallengeParticipantEntity } from "../challenge-participant";
 import { DraftPokemonEntity } from "../draft/draft-pokemon.entity";
+import { DraftEntity } from "../draft/draft.entity";
 
 @Entity({
   name: "draft_selection",
@@ -42,4 +43,13 @@ export class DraftSelectionEntity {
 
   @Column()
   pokemonId!: number;
+
+  @ManyToOne(
+    () => DraftEntity,
+    (draft) => draft.selections
+  )
+  @JoinColumn({
+    name: "draft_id",
+  })
+  draft!: Promise<DraftEntity>;
 }

--- a/packages/back-end/src/draft-selection/draft-selection.entity.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.entity.ts
@@ -39,4 +39,7 @@ export class DraftSelectionEntity {
     name: "pokemon_id",
   })
   pokemon!: Promise<DraftPokemonEntity | null>;
+
+  @Column()
+  pokemonId!: number;
 }

--- a/packages/back-end/src/draft-selection/draft-selection.entity.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.entity.ts
@@ -44,10 +44,7 @@ export class DraftSelectionEntity {
   @Column()
   pokemonId!: number;
 
-  @ManyToOne(
-    () => DraftEntity,
-    (draft) => draft.selections
-  )
+  @ManyToOne(() => DraftEntity, (draft) => draft.selections)
   @JoinColumn({
     name: "draft_id",
   })

--- a/packages/back-end/src/draft-selection/draft-selection.mock.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.mock.ts
@@ -1,7 +1,16 @@
+import { DraftSelectionEntity } from ".";
 import { generateMockPokemon } from "../pokemon/pokemon.mock";
 import { generateRandomNumber, generateRandomString } from "../random";
 import { DraftSelection, DraftSelectionRow } from "./draft-selection";
 import { FinalizeDraftSelectionRequest } from "./finalize-draft-selection-request";
+
+export const generateMockDraftSelectionEntity = (): DraftSelectionEntity => {
+  const entity = new DraftSelectionEntity()
+  entity.id = generateRandomNumber()
+  entity.pickNumber = generateRandomNumber()
+  entity.roundNumber = generateRandomNumber()
+  return entity
+}
 
 export const generateMockDraftSelectionRow = (
   pokemonId?: number | null

--- a/packages/back-end/src/draft-selection/draft-selection.mock.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.mock.ts
@@ -11,7 +11,7 @@ export const generateMockDraftSelectionRow = (
   pick: generateRandomNumber(),
   userNickname: generateRandomString(),
   pokemonId: pokemonId === undefined ? generateRandomNumber() : pokemonId,
-  userId: generateRandomNumber()
+  userId: generateRandomNumber(),
 });
 
 export const generateMockDraftSelection = (): DraftSelection => ({
@@ -20,9 +20,10 @@ export const generateMockDraftSelection = (): DraftSelection => ({
   pick: generateRandomNumber(),
   userNickname: generateRandomString(),
   selection: generateMockPokemon(),
-  userId: generateRandomNumber()
+  userId: generateRandomNumber(),
 });
 
-export const generateMockFinalizeDraftSelectionRequest = (): FinalizeDraftSelectionRequest => ({
-  draftPokemonId: generateRandomNumber()
-})
+export const generateMockFinalizeDraftSelectionRequest =
+  (): FinalizeDraftSelectionRequest => ({
+    draftPokemonId: generateRandomNumber(),
+  });

--- a/packages/back-end/src/draft-selection/draft-selection.mock.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.mock.ts
@@ -10,6 +10,7 @@ export const generateMockDraftSelectionRow = (
   pick: generateRandomNumber(),
   userNickname: generateRandomString(),
   pokemonId: pokemonId === undefined ? generateRandomNumber() : pokemonId,
+  userId: generateRandomNumber()
 });
 
 export const generateMockDraftSelection = (): DraftSelection => ({
@@ -18,4 +19,5 @@ export const generateMockDraftSelection = (): DraftSelection => ({
   pick: generateRandomNumber(),
   userNickname: generateRandomString(),
   selection: generateMockPokemon(),
+  userId: generateRandomNumber()
 });

--- a/packages/back-end/src/draft-selection/draft-selection.mock.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.mock.ts
@@ -1,4 +1,5 @@
 import { DraftSelectionEntity } from ".";
+import { generateMockChallengeParticipantEntity } from "../challenge-participant/challenge-participant.mock";
 import { generateMockPokemon } from "../pokemon/pokemon.mock";
 import { generateRandomNumber, generateRandomString } from "../random";
 import { DraftSelection, DraftSelectionRow } from "./draft-selection";
@@ -9,6 +10,7 @@ export const generateMockDraftSelectionEntity = (): DraftSelectionEntity => {
   entity.id = generateRandomNumber()
   entity.pickNumber = generateRandomNumber()
   entity.roundNumber = generateRandomNumber()
+  entity.challengeParticipant = Promise.resolve(generateMockChallengeParticipantEntity())
   return entity
 }
 

--- a/packages/back-end/src/draft-selection/draft-selection.mock.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.mock.ts
@@ -1,6 +1,7 @@
 import { generateMockPokemon } from "../pokemon/pokemon.mock";
 import { generateRandomNumber, generateRandomString } from "../random";
 import { DraftSelection, DraftSelectionRow } from "./draft-selection";
+import { FinalizeDraftSelectionRequest } from "./finalize-draft-selection-request";
 
 export const generateMockDraftSelectionRow = (
   pokemonId?: number | null
@@ -21,3 +22,7 @@ export const generateMockDraftSelection = (): DraftSelection => ({
   selection: generateMockPokemon(),
   userId: generateRandomNumber()
 });
+
+export const generateMockFinalizeDraftSelectionRequest = (): FinalizeDraftSelectionRequest => ({
+  draftPokemonId: generateRandomNumber()
+})

--- a/packages/back-end/src/draft-selection/draft-selection.mock.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.mock.ts
@@ -6,13 +6,15 @@ import { DraftSelection, DraftSelectionRow } from "./draft-selection";
 import { FinalizeDraftSelectionRequest } from "./finalize-draft-selection-request";
 
 export const generateMockDraftSelectionEntity = (): DraftSelectionEntity => {
-  const entity = new DraftSelectionEntity()
-  entity.id = generateRandomNumber()
-  entity.pickNumber = generateRandomNumber()
-  entity.roundNumber = generateRandomNumber()
-  entity.challengeParticipant = Promise.resolve(generateMockChallengeParticipantEntity())
-  return entity
-}
+  const entity = new DraftSelectionEntity();
+  entity.id = generateRandomNumber();
+  entity.pickNumber = generateRandomNumber();
+  entity.roundNumber = generateRandomNumber();
+  entity.challengeParticipant = Promise.resolve(
+    generateMockChallengeParticipantEntity()
+  );
+  return entity;
+};
 
 export const generateMockDraftSelectionRow = (
   pokemonId?: number | null

--- a/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
@@ -117,13 +117,13 @@ describe("DraftSelectionRepository", () => {
     });
   });
 
-  describe("getOneByIdAndUserId", () => {
+  describe("getPendingOneByIdAndUserId", () => {
     it("returns an entity if one exists with a given id and user ID", async () => {
       const [draftSelection] = createdSelections;
       const participant = await draftSelection.challengeParticipant;
       const user = await participant.user;
       const gottenDraftSelection =
-        await draftSelectionRepository.getOneWithIdAndUserId(
+        await draftSelectionRepository.getPendingOneWithIdAndUserId(
           draftSelection.id,
           user.id
         );
@@ -140,16 +140,31 @@ describe("DraftSelectionRepository", () => {
     it("returns undefined if given a bogus id", async () => {
       const [user] = users;
       const gottenDraftSelection =
-        await draftSelectionRepository.getOneWithIdAndUserId(100000, user.id);
+        await draftSelectionRepository.getPendingOneWithIdAndUserId(100000, user.id);
       expect(gottenDraftSelection).toBeUndefined();
     });
 
     it("returns undefined if given a bogus user id", async () => {
       const [draftSelection] = createdSelections;
       const gottenDraftSelection =
-        await draftSelectionRepository.getOneWithIdAndUserId(
+        await draftSelectionRepository.getPendingOneWithIdAndUserId(
           draftSelection.id,
           1000000
+        );
+      expect(gottenDraftSelection).toBeUndefined();
+    });
+
+    it("returns undefined if the pick has already been finalized", async () => {
+      let [draftSelection] = createdSelections;
+      const [draftPokemon] = await seedDraftPokemon(getRepository(DraftPokemonEntity), draft, 1)
+      draftSelection.pokemonId = draftPokemon.id
+      draftSelection = await draftSelectionRepository.save(draftSelection)
+      const participant = await draftSelection.challengeParticipant;
+      const user = await participant.user;
+      const gottenDraftSelection =
+        await draftSelectionRepository.getPendingOneWithIdAndUserId(
+          draftSelection.id,
+          user.id
         );
       expect(gottenDraftSelection).toBeUndefined();
     });

--- a/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
@@ -140,7 +140,10 @@ describe("DraftSelectionRepository", () => {
     it("returns undefined if given a bogus id", async () => {
       const [user] = users;
       const gottenDraftSelection =
-        await draftSelectionRepository.getPendingOneWithIdAndUserId(100000, user.id);
+        await draftSelectionRepository.getPendingOneWithIdAndUserId(
+          100000,
+          user.id
+        );
       expect(gottenDraftSelection).toBeUndefined();
     });
 
@@ -156,9 +159,13 @@ describe("DraftSelectionRepository", () => {
 
     it("returns undefined if the pick has already been finalized", async () => {
       let [draftSelection] = createdSelections;
-      const [draftPokemon] = await seedDraftPokemon(getRepository(DraftPokemonEntity), draft, 1)
-      draftSelection.pokemonId = draftPokemon.id
-      draftSelection = await draftSelectionRepository.save(draftSelection)
+      const [draftPokemon] = await seedDraftPokemon(
+        getRepository(DraftPokemonEntity),
+        draft,
+        1
+      );
+      draftSelection.pokemonId = draftPokemon.id;
+      draftSelection = await draftSelectionRepository.save(draftSelection);
       const participant = await draftSelection.challengeParticipant;
       const user = await participant.user;
       const gottenDraftSelection =

--- a/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
@@ -156,12 +156,12 @@ describe("DraftSelectionRepository", () => {
   });
 
   describe("getPendingSelectionsBeforeSelection", () => {
-    let newChallenge: ChallengeEntity
-    let newDraft: DraftEntity
-    let newChallengeParticipants: ChallengeParticipantEntity[] = []
+    let newChallenge: ChallengeEntity;
+    let newDraft: DraftEntity;
+    let newChallengeParticipants: ChallengeParticipantEntity[] = [];
 
     beforeEach(async () => {
-      newChallengeParticipants = []
+      newChallengeParticipants = [];
       newChallenge = await seedChallenge(challengeRepository);
       newDraft = await seedDraft(draftRepository, newChallenge);
       for (const user of users) {
@@ -172,44 +172,56 @@ describe("DraftSelectionRepository", () => {
         );
         newChallengeParticipants.push(challengeParticipant);
       }
-    })
+    });
 
     it("returns an empty array if every selection before the provided one has been made", async () => {
-      const draftPokemon = await seedDraftPokemon(getRepository(DraftPokemonEntity), newDraft, newChallengeParticipants.length)
-      const selections: DraftSelectionEntity[] = []
-      let pickNumber = 1
+      const draftPokemon = await seedDraftPokemon(
+        getRepository(DraftPokemonEntity),
+        newDraft,
+        newChallengeParticipants.length
+      );
+      const selections: DraftSelectionEntity[] = [];
+      let pickNumber = 1;
       for (const participant of newChallengeParticipants) {
-        const draftSelection = draftSelectionRepository.create()
-        draftSelection.roundNumber = 1
-        draftSelection.pickNumber = pickNumber
-        draftSelection.challengeParticipant = Promise.resolve(participant)
-        draftSelection.pokemonId = draftPokemon[pickNumber - 1].id
-        draftSelection.draft = Promise.resolve(newDraft)
-        selections.push(await draftSelectionRepository.save(draftSelection))
-        pickNumber++
+        const draftSelection = draftSelectionRepository.create();
+        draftSelection.roundNumber = 1;
+        draftSelection.pickNumber = pickNumber;
+        draftSelection.challengeParticipant = Promise.resolve(participant);
+        draftSelection.pokemonId = draftPokemon[pickNumber - 1].id;
+        draftSelection.draft = Promise.resolve(newDraft);
+        selections.push(await draftSelectionRepository.save(draftSelection));
+        pickNumber++;
       }
-      const selectionToTest = last(selections) as DraftSelectionEntity
-      const pendingSelections = await draftSelectionRepository.getPendingSelectionsBeforeSelection(selectionToTest, newDraft.id)
-      expect(pendingSelections).toBeTruthy()
-      expect(pendingSelections).toHaveLength(0)
-    })
+      const selectionToTest = last(selections) as DraftSelectionEntity;
+      const pendingSelections =
+        await draftSelectionRepository.getPendingSelectionsBeforeSelection(
+          selectionToTest,
+          newDraft.id
+        );
+      expect(pendingSelections).toBeTruthy();
+      expect(pendingSelections).toHaveLength(0);
+    });
 
     it("returns the previous selections if every selection before the provided one has not been made", async () => {
-      const selections: DraftSelectionEntity[] = []
-      let pickNumber = 1
+      const selections: DraftSelectionEntity[] = [];
+      let pickNumber = 1;
       for (const participant of newChallengeParticipants) {
-        const draftSelection = draftSelectionRepository.create()
-        draftSelection.roundNumber = 1
-        draftSelection.pickNumber = pickNumber
-        draftSelection.challengeParticipant = Promise.resolve(participant)
-        draftSelection.draft = Promise.resolve(newDraft)
-        selections.push(await draftSelectionRepository.save(draftSelection))
-        pickNumber++
+        const draftSelection = draftSelectionRepository.create();
+        draftSelection.roundNumber = 1;
+        draftSelection.pickNumber = pickNumber;
+        draftSelection.challengeParticipant = Promise.resolve(participant);
+        draftSelection.draft = Promise.resolve(newDraft);
+        selections.push(await draftSelectionRepository.save(draftSelection));
+        pickNumber++;
       }
-      const selectionToTest = selections.pop() as DraftSelectionEntity
-      const pendingSelections = await draftSelectionRepository.getPendingSelectionsBeforeSelection(selectionToTest, newDraft.id)
-      expect(pendingSelections).toBeTruthy()
-      expect(pendingSelections).toHaveLength(selections.length)
-    })
-  })
+      const selectionToTest = selections.pop() as DraftSelectionEntity;
+      const pendingSelections =
+        await draftSelectionRepository.getPendingSelectionsBeforeSelection(
+          selectionToTest,
+          newDraft.id
+        );
+      expect(pendingSelections).toBeTruthy();
+      expect(pendingSelections).toHaveLength(selections.length);
+    });
+  });
 });

--- a/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
@@ -16,6 +16,7 @@ import {
   clearAllDraftSelections,
   seedDraftSelection,
 } from "./draft-selection.seed";
+import { orderBy } from "lodash";
 
 describe("DraftSelectionService (integration)", () => {
   let draftSelectionRepository: DraftSelectionRepository;
@@ -75,9 +76,14 @@ describe("DraftSelectionService (integration)", () => {
       const gottenSelections = await draftSelectionRepository.getAllForDraftId(
         draft.id
       );
-      expect(gottenSelections).toHaveLength(createdSelections.length);
-      for (let i = 0; i < createdSelections.length; i++) {
-        const createdSelection = createdSelections[i];
+      const expectedSelections = orderBy(
+        createdSelections,
+        ["roundNumber", "pickNumber"],
+        ["asc", "asc"]
+      );
+      expect(gottenSelections).toHaveLength(expectedSelections.length);
+      for (let i = 0; i < expectedSelections.length; i++) {
+        const createdSelection = expectedSelections[i];
         const correspondingSelection = gottenSelections[i];
         expect(correspondingSelection.id).toEqual(createdSelection.id);
         expect(createdSelection.roundNumber).toBeTruthy();

--- a/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
@@ -195,8 +195,7 @@ describe("DraftSelectionRepository", () => {
       const selectionToTest = last(selections) as DraftSelectionEntity;
       const pendingSelections =
         await draftSelectionRepository.getPendingSelectionsBeforeSelection(
-          selectionToTest,
-          newDraft.id
+          selectionToTest
         );
       expect(pendingSelections).toBeTruthy();
       expect(pendingSelections).toHaveLength(0);
@@ -217,8 +216,7 @@ describe("DraftSelectionRepository", () => {
       const selectionToTest = selections.pop() as DraftSelectionEntity;
       const pendingSelections =
         await draftSelectionRepository.getPendingSelectionsBeforeSelection(
-          selectionToTest,
-          newDraft.id
+          selectionToTest
         );
       expect(pendingSelections).toBeTruthy();
       expect(pendingSelections).toHaveLength(selections.length);

--- a/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
@@ -82,8 +82,10 @@ describe("DraftSelectionService (integration)", () => {
         );
         const participant = await createdSelection.challengeParticipant;
         const user = await participant.user;
+        expect(user.id).toBeTruthy();
         expect(user.nickname).toBeTruthy();
         expect(correspondingSelection.userNickname).toEqual(user.nickname);
+        expect(correspondingSelection.userId).toEqual(user.id);
       }
     });
 

--- a/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
@@ -62,7 +62,9 @@ describe("DraftSelectionRepository", () => {
     for (const challengeParticipant of challengeParticipants) {
       const createdSelection = await seedDraftSelection(
         draftSelectionRepository,
-        challengeParticipant
+        challengeParticipant,
+        draft,
+        createdSelections.length + 1
       );
       createdSelections.push(createdSelection);
     }
@@ -83,8 +85,6 @@ describe("DraftSelectionRepository", () => {
         ["roundNumber", "pickNumber"],
         ["asc", "asc"]
       );
-      console.log(gottenSelections.map(({ id, pick, round }) => ({ id, pick, round })))
-      console.log(expectedSelections.map(({ id, pickNumber, roundNumber }) => ({ id, pickNumber, roundNumber })))
       expect(gottenSelections).toHaveLength(expectedSelections.length);
       for (let i = 0; i < expectedSelections.length; i++) {
         const createdSelection = expectedSelections[i];
@@ -184,6 +184,7 @@ describe("DraftSelectionRepository", () => {
         draftSelection.pickNumber = pickNumber
         draftSelection.challengeParticipant = Promise.resolve(participant)
         draftSelection.pokemonId = draftPokemon[pickNumber - 1].id
+        draftSelection.draft = Promise.resolve(newDraft)
         selections.push(await draftSelectionRepository.save(draftSelection))
         pickNumber++
       }
@@ -201,6 +202,7 @@ describe("DraftSelectionRepository", () => {
         draftSelection.roundNumber = 1
         draftSelection.pickNumber = pickNumber
         draftSelection.challengeParticipant = Promise.resolve(participant)
+        draftSelection.draft = Promise.resolve(newDraft)
         selections.push(await draftSelectionRepository.save(draftSelection))
         pickNumber++
       }

--- a/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
@@ -26,7 +26,7 @@ describe("DraftSelectionService (integration)", () => {
   let users: UserEntity[];
   const challengeParticipants: ChallengeParticipantEntity[] = [];
   let draft: DraftEntity;
-  const createdSelections: DraftSelectionEntity[] = [];
+  let createdSelections: DraftSelectionEntity[] = [];
 
   beforeAll(async () => {
     await establishDbConnection();
@@ -51,6 +51,7 @@ describe("DraftSelectionService (integration)", () => {
 
   beforeEach(async () => {
     draftSelectionRepository = getCustomRepository(DraftSelectionRepository);
+    createdSelections = []
 
     for (const challengeParticipant of challengeParticipants) {
       const createdSelection = await seedDraftSelection(
@@ -110,7 +111,9 @@ describe("DraftSelectionService (integration)", () => {
       const user = await participant.user
       const gottenDraftSelection = await draftSelectionRepository.getOneWithIdAndUserId(draftSelection.id, user.id)
       expect(gottenDraftSelection).toBeTruthy()
-      expect(gottenDraftSelection).toEqual(draftSelection)
+      expect(gottenDraftSelection?.id).toEqual(draftSelection.id)
+      expect(gottenDraftSelection?.pickNumber).toEqual(draftSelection.pickNumber)
+      expect(gottenDraftSelection?.roundNumber).toEqual(draftSelection.roundNumber)
     })
   })
 });

--- a/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
@@ -12,7 +12,10 @@ import { establishDbConnection } from "../test/create-db-connection";
 import { UserEntity } from "../user/user.entity";
 import { seedUsers } from "../user/user.seed";
 import { DraftSelectionEntity } from "./draft-selection.entity";
-import { clearAllDraftSelections, seedDraftSelection } from "./draft-selection.seed";
+import {
+  clearAllDraftSelections,
+  seedDraftSelection,
+} from "./draft-selection.seed";
 
 describe("DraftSelectionService (integration)", () => {
   let draftSelectionRepository: DraftSelectionRepository;
@@ -51,7 +54,7 @@ describe("DraftSelectionService (integration)", () => {
 
   beforeEach(async () => {
     draftSelectionRepository = getCustomRepository(DraftSelectionRepository);
-    createdSelections = []
+    createdSelections = [];
 
     for (const challengeParticipant of challengeParticipants) {
       const createdSelection = await seedDraftSelection(
@@ -63,8 +66,8 @@ describe("DraftSelectionService (integration)", () => {
   });
 
   afterEach(async () => {
-    await clearAllDraftSelections()
-  })
+    await clearAllDraftSelections();
+  });
 
   describe("getAllForDraftId", () => {
     it("returns properly mapped draft selections from a given draft", async () => {
@@ -106,26 +109,39 @@ describe("DraftSelectionService (integration)", () => {
 
   describe("getOneByIdAndUserId", () => {
     it("returns an entity if one exists with a given id and user ID", async () => {
-      const [draftSelection] = createdSelections
-      const participant = await draftSelection.challengeParticipant
-      const user = await participant.user
-      const gottenDraftSelection = await draftSelectionRepository.getOneWithIdAndUserId(draftSelection.id, user.id)
-      expect(gottenDraftSelection).toBeTruthy()
-      expect(gottenDraftSelection?.id).toEqual(draftSelection.id)
-      expect(gottenDraftSelection?.pickNumber).toEqual(draftSelection.pickNumber)
-      expect(gottenDraftSelection?.roundNumber).toEqual(draftSelection.roundNumber)
-    })
+      const [draftSelection] = createdSelections;
+      const participant = await draftSelection.challengeParticipant;
+      const user = await participant.user;
+      const gottenDraftSelection =
+        await draftSelectionRepository.getOneWithIdAndUserId(
+          draftSelection.id,
+          user.id
+        );
+      expect(gottenDraftSelection).toBeTruthy();
+      expect(gottenDraftSelection?.id).toEqual(draftSelection.id);
+      expect(gottenDraftSelection?.pickNumber).toEqual(
+        draftSelection.pickNumber
+      );
+      expect(gottenDraftSelection?.roundNumber).toEqual(
+        draftSelection.roundNumber
+      );
+    });
 
     it("returns undefined if given a bogus id", async () => {
-      const [user] = users
-      const gottenDraftSelection = await draftSelectionRepository.getOneWithIdAndUserId(100000, user.id)
-      expect(gottenDraftSelection).toBeUndefined()
-    })
+      const [user] = users;
+      const gottenDraftSelection =
+        await draftSelectionRepository.getOneWithIdAndUserId(100000, user.id);
+      expect(gottenDraftSelection).toBeUndefined();
+    });
 
     it("returns undefined if given a bogus user id", async () => {
-      const [draftSelection] = createdSelections
-      const gottenDraftSelection = await draftSelectionRepository.getOneWithIdAndUserId(draftSelection.id, 1000000)
-      expect(gottenDraftSelection).toBeUndefined()
-    })
-  })
+      const [draftSelection] = createdSelections;
+      const gottenDraftSelection =
+        await draftSelectionRepository.getOneWithIdAndUserId(
+          draftSelection.id,
+          1000000
+        );
+      expect(gottenDraftSelection).toBeUndefined();
+    });
+  });
 });

--- a/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.spec.ts
@@ -115,5 +115,17 @@ describe("DraftSelectionService (integration)", () => {
       expect(gottenDraftSelection?.pickNumber).toEqual(draftSelection.pickNumber)
       expect(gottenDraftSelection?.roundNumber).toEqual(draftSelection.roundNumber)
     })
+
+    it("returns undefined if given a bogus id", async () => {
+      const [user] = users
+      const gottenDraftSelection = await draftSelectionRepository.getOneWithIdAndUserId(100000, user.id)
+      expect(gottenDraftSelection).toBeUndefined()
+    })
+
+    it("returns undefined if given a bogus user id", async () => {
+      const [draftSelection] = createdSelections
+      const gottenDraftSelection = await draftSelectionRepository.getOneWithIdAndUserId(draftSelection.id, 1000000)
+      expect(gottenDraftSelection).toBeUndefined()
+    })
   })
 });

--- a/packages/back-end/src/draft-selection/draft-selection.repository.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.ts
@@ -9,15 +9,13 @@ export class DraftSelectionRepository extends Repository<DraftSelectionEntity> {
       .leftJoin("draftSelection.pokemon", "pokemon")
       .innerJoin("draftSelection.challengeParticipant", "challengeParticipant")
       .innerJoin("challengeParticipant.user", "user")
-      .innerJoin("challengeParticipant.challenge", "challenge")
-      .innerJoin("challenge.draft", "draft")
       .select("draftSelection.id", "id")
       .addSelect("draftSelection.roundNumber", "round")
       .addSelect("draftSelection.pickNumber", "pick")
       .addSelect("user.id", "userId")
       .addSelect("user.nickname", "userNickname")
       .addSelect("pokemon.pokemonId", "pokemonId")
-      .where("draft.id = :draftId", { draftId })
+      .where("draftSelection.draftId = :draftId", { draftId })
       .orderBy({
         "draftSelection.roundNumber": "ASC",
         "draftSelection.pickNumber": "ASC",
@@ -40,11 +38,7 @@ export class DraftSelectionRepository extends Repository<DraftSelectionEntity> {
   public async getPendingSelectionsBeforeSelection(selection: DraftSelectionEntity, draftId: number): Promise<DraftSelectionEntity[]> {
     const { roundNumber, pickNumber } = selection
     return this.createQueryBuilder("draftSelection")
-      .innerJoin("draftSelection.challengeParticipant", "challengeParticipant")
-      .innerJoin("challengeParticipant.user", "user")
-      .innerJoin("challengeParticipant.challenge", "challenge")
-      .innerJoin("challenge.draft", "draft")
-      .where("draft.id = :draftId", { draftId })
+      .where("draftSelection.draftId = :draftId", { draftId })
       .andWhere("draftSelection.roundNumber <= :roundNumber", { roundNumber })
       .andWhere("draftSelection.pickNumber < :pickNumber", { pickNumber })
       .andWhere("draftSelection.pokemonId is null")

--- a/packages/back-end/src/draft-selection/draft-selection.repository.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.ts
@@ -14,6 +14,7 @@ export class DraftSelectionRepository extends Repository<DraftSelectionEntity> {
       .select("draftSelection.id", "id")
       .addSelect("draftSelection.roundNumber", "round")
       .addSelect("draftSelection.pickNumber", "pick")
+      .addSelect("user.id", "userId")
       .addSelect("user.nickname", "userNickname")
       .addSelect("pokemon.pokemonId", "pokemonId")
       .where("draft.id = :draftId", { draftId })

--- a/packages/back-end/src/draft-selection/draft-selection.repository.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.ts
@@ -23,7 +23,7 @@ export class DraftSelectionRepository extends Repository<DraftSelectionEntity> {
       .getRawMany<DraftSelectionRow>();
   }
 
-  public async getOneWithIdAndUserId(
+  public async getPendingOneWithIdAndUserId(
     id: number,
     userId: number
   ): Promise<DraftSelectionEntity | undefined> {
@@ -32,6 +32,7 @@ export class DraftSelectionRepository extends Repository<DraftSelectionEntity> {
       .innerJoin("challengeParticipant.user", "user")
       .where("draftSelection.id = :id", { id })
       .andWhere("user.id = :userId", { userId })
+      .andWhere("draftSelection.pokemonId is null")
       .getOne();
   }
 

--- a/packages/back-end/src/draft-selection/draft-selection.repository.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.ts
@@ -22,6 +22,11 @@ export class DraftSelectionRepository extends Repository<DraftSelectionEntity> {
   }
 
   public async getOneWithIdAndUserId(id: number, userId: number): Promise<DraftSelectionEntity | undefined> {
-    return this.findOne(id)
+    return this.createQueryBuilder("draftSelection")
+        .innerJoin("draftSelection.challengeParticipant", "challengeParticipant")
+        .innerJoin("challengeParticipant.user", "user")
+        .where("draftSelection.id = :id", { id })
+        .andWhere("user.id = :userId", { userId })
+        .getOne();
   }
 }

--- a/packages/back-end/src/draft-selection/draft-selection.repository.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.ts
@@ -20,4 +20,13 @@ export class DraftSelectionRepository extends Repository<DraftSelectionEntity> {
       .where("draft.id = :draftId", { draftId })
       .getRawMany<DraftSelectionRow>();
   }
+
+  public async getOneWithIdAndUserId(id: number, userId: number): Promise<DraftSelectionEntity | undefined> {
+    return this.createQueryBuilder("draftSelection")
+        .innerJoin("draftSelection.challengeParticipant", "challengeParticipant")
+        .innerJoin("challengeParticipant.user", "user")
+        .where("draftSelection.id = :id", { id })
+        .andWhere("user.id = :userId", { userId })
+        .getOne();
+  }
 }

--- a/packages/back-end/src/draft-selection/draft-selection.repository.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.ts
@@ -37,7 +37,7 @@ export class DraftSelectionRepository extends Repository<DraftSelectionEntity> {
       .getOne();
   }
 
-  public async getPendingSelectionsBeforeSelection(selection: DraftSelectionEntity, draftId: number): Promise<DraftSelectionEntity[] | undefined> {
+  public async getPendingSelectionsBeforeSelection(selection: DraftSelectionEntity, draftId: number): Promise<DraftSelectionEntity[]> {
     const { roundNumber, pickNumber } = selection
     return this.createQueryBuilder("draftSelection")
       .innerJoin("draftSelection.challengeParticipant", "challengeParticipant")

--- a/packages/back-end/src/draft-selection/draft-selection.repository.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.ts
@@ -21,12 +21,15 @@ export class DraftSelectionRepository extends Repository<DraftSelectionEntity> {
       .getRawMany<DraftSelectionRow>();
   }
 
-  public async getOneWithIdAndUserId(id: number, userId: number): Promise<DraftSelectionEntity | undefined> {
+  public async getOneWithIdAndUserId(
+    id: number,
+    userId: number
+  ): Promise<DraftSelectionEntity | undefined> {
     return this.createQueryBuilder("draftSelection")
-        .innerJoin("draftSelection.challengeParticipant", "challengeParticipant")
-        .innerJoin("challengeParticipant.user", "user")
-        .where("draftSelection.id = :id", { id })
-        .andWhere("user.id = :userId", { userId })
-        .getOne();
+      .innerJoin("draftSelection.challengeParticipant", "challengeParticipant")
+      .innerJoin("challengeParticipant.user", "user")
+      .where("draftSelection.id = :id", { id })
+      .andWhere("user.id = :userId", { userId })
+      .getOne();
   }
 }

--- a/packages/back-end/src/draft-selection/draft-selection.repository.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.ts
@@ -36,4 +36,18 @@ export class DraftSelectionRepository extends Repository<DraftSelectionEntity> {
       .andWhere("user.id = :userId", { userId })
       .getOne();
   }
+
+  public async getPendingSelectionsBeforeSelection(selection: DraftSelectionEntity, draftId: number): Promise<DraftSelectionEntity[] | undefined> {
+    const { roundNumber, pickNumber } = selection
+    return this.createQueryBuilder("draftSelection")
+      .innerJoin("draftSelection.challengeParticipant", "challengeParticipant")
+      .innerJoin("challengeParticipant.user", "user")
+      .innerJoin("challengeParticipant.challenge", "challenge")
+      .innerJoin("challenge.draft", "draft")
+      .where("draft.id = :draftId", { draftId })
+      .andWhere("draftSelection.roundNumber <= :roundNumber", { roundNumber })
+      .andWhere("draftSelection.pickNumber < :pickNumber", { pickNumber })
+      .andWhere("draftSelection.pokemonId is null")
+      .getMany();
+  }
 }

--- a/packages/back-end/src/draft-selection/draft-selection.repository.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.ts
@@ -22,11 +22,6 @@ export class DraftSelectionRepository extends Repository<DraftSelectionEntity> {
   }
 
   public async getOneWithIdAndUserId(id: number, userId: number): Promise<DraftSelectionEntity | undefined> {
-    return this.createQueryBuilder("draftSelection")
-        .innerJoin("draftSelection.challengeParticipant", "challengeParticipant")
-        .innerJoin("challengeParticipant.user", "user")
-        .where("draftSelection.id = :id", { id })
-        .andWhere("user.id = :userId", { userId })
-        .getOne();
+    return this.findOne(id)
   }
 }

--- a/packages/back-end/src/draft-selection/draft-selection.repository.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.ts
@@ -35,8 +35,11 @@ export class DraftSelectionRepository extends Repository<DraftSelectionEntity> {
       .getOne();
   }
 
-  public async getPendingSelectionsBeforeSelection(selection: DraftSelectionEntity, draftId: number): Promise<DraftSelectionEntity[]> {
-    const { roundNumber, pickNumber } = selection
+  public async getPendingSelectionsBeforeSelection(
+    selection: DraftSelectionEntity,
+    draftId: number
+  ): Promise<DraftSelectionEntity[]> {
+    const { roundNumber, pickNumber } = selection;
     return this.createQueryBuilder("draftSelection")
       .where("draftSelection.draftId = :draftId", { draftId })
       .andWhere("draftSelection.roundNumber <= :roundNumber", { roundNumber })

--- a/packages/back-end/src/draft-selection/draft-selection.repository.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.ts
@@ -18,6 +18,10 @@ export class DraftSelectionRepository extends Repository<DraftSelectionEntity> {
       .addSelect("user.nickname", "userNickname")
       .addSelect("pokemon.pokemonId", "pokemonId")
       .where("draft.id = :draftId", { draftId })
+      .orderBy({
+        "draftSelection.roundNumber": "ASC",
+        "draftSelection.pickNumber": "ASC",
+      })
       .getRawMany<DraftSelectionRow>();
   }
 

--- a/packages/back-end/src/draft-selection/draft-selection.repository.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.repository.ts
@@ -36,10 +36,9 @@ export class DraftSelectionRepository extends Repository<DraftSelectionEntity> {
   }
 
   public async getPendingSelectionsBeforeSelection(
-    selection: DraftSelectionEntity,
-    draftId: number
+    selection: DraftSelectionEntity
   ): Promise<DraftSelectionEntity[]> {
-    const { roundNumber, pickNumber } = selection;
+    const { roundNumber, pickNumber, draftId } = selection;
     return this.createQueryBuilder("draftSelection")
       .where("draftSelection.draftId = :draftId", { draftId })
       .andWhere("draftSelection.roundNumber <= :roundNumber", { roundNumber })

--- a/packages/back-end/src/draft-selection/draft-selection.seed.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.seed.ts
@@ -1,26 +1,26 @@
 import { getRepository, Repository } from "typeorm";
 import { ChallengeParticipantEntity } from "../challenge-participant";
-import { getRandomInt } from "../random";
+import { DraftEntity } from "../draft/draft.entity";
 import { DraftSelectionEntity } from "./draft-selection.entity";
 
 export const clearAllDraftSelections = async (): Promise<void> => {
-  await getRepository(DraftSelectionEntity)
-    .createQueryBuilder()
-    .delete()
-    .execute();
+  await getRepository(DraftSelectionEntity).query(`DELETE FROM draft_selection`)
 };
 
 export const seedDraftSelections = async (
   repository: Repository<DraftSelectionEntity>,
   participant: ChallengeParticipantEntity,
-  count = 20
+  draft: DraftEntity,
+  count = 20,
+  pickNumber?: number
 ): Promise<DraftSelectionEntity[]> => {
   const draftSelections: DraftSelectionEntity[] = [];
   for (let i = 0; i < count; i++) {
     const draftSelection = repository.create();
-    draftSelection.roundNumber = getRandomInt(1, 7);
-    draftSelection.pickNumber = getRandomInt(1, 5);
+    draftSelection.roundNumber = 1;
+    draftSelection.pickNumber = pickNumber || i + 1;
     draftSelection.challengeParticipant = Promise.resolve(participant);
+    draftSelection.draft = Promise.resolve(draft)
     draftSelections.push(draftSelection);
   }
   return repository.save(draftSelections);
@@ -28,12 +28,16 @@ export const seedDraftSelections = async (
 
 export const seedDraftSelection = async (
   repository: Repository<DraftSelectionEntity>,
-  participant: ChallengeParticipantEntity
+  participant: ChallengeParticipantEntity,
+  draft: DraftEntity,
+  pickNumber?: number
 ): Promise<DraftSelectionEntity> => {
   const [draftSelection] = await seedDraftSelections(
     repository,
     participant,
-    1
+    draft,
+    1,
+    pickNumber
   );
   return draftSelection;
 };

--- a/packages/back-end/src/draft-selection/draft-selection.seed.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.seed.ts
@@ -4,7 +4,9 @@ import { DraftEntity } from "../draft/draft.entity";
 import { DraftSelectionEntity } from "./draft-selection.entity";
 
 export const clearAllDraftSelections = async (): Promise<void> => {
-  await getRepository(DraftSelectionEntity).query(`DELETE FROM draft_selection`)
+  await getRepository(DraftSelectionEntity).query(
+    `DELETE FROM draft_selection`
+  );
 };
 
 export const seedDraftSelections = async (
@@ -20,7 +22,7 @@ export const seedDraftSelections = async (
     draftSelection.roundNumber = 1;
     draftSelection.pickNumber = pickNumber || i + 1;
     draftSelection.challengeParticipant = Promise.resolve(participant);
-    draftSelection.draft = Promise.resolve(draft)
+    draftSelection.draft = Promise.resolve(draft);
     draftSelections.push(draftSelection);
   }
   return repository.save(draftSelections);

--- a/packages/back-end/src/draft-selection/draft-selection.seed.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.seed.ts
@@ -19,7 +19,7 @@ export const seedDraftSelections = async (
   for (let i = 0; i < count; i++) {
     const draftSelection = repository.create();
     draftSelection.roundNumber = getRandomInt(1, 7);
-    draftSelection.pickNumber = getRandomInt(1, 33);
+    draftSelection.pickNumber = getRandomInt(1, 5);
     draftSelection.challengeParticipant = Promise.resolve(participant);
     draftSelections.push(draftSelection);
   }

--- a/packages/back-end/src/draft-selection/draft-selection.service.spec.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.service.spec.ts
@@ -8,6 +8,7 @@ import { generateMockDraftSelectionRow } from "./draft-selection.mock";
 import { generateRandomNumber } from "../random";
 import { last } from "lodash";
 import { DraftSelection } from "./draft-selection";
+import { INVALID_NUMBER_CASES, NEGATIVE_NUMBER_CASES } from "../test/cases";
 
 describe("DraftSelectionService", () => {
   let draftSelectionService: DraftSelectionService;
@@ -24,7 +25,7 @@ describe("DraftSelectionService", () => {
   });
 
   describe("getAllForDraft", () => {
-    it.each([null, undefined, "", NaN])(
+    it.each([...INVALID_NUMBER_CASES])(
       "throws a ZodError if draft id given = %p",
       async (draftId: unknown) => {
         await expect(
@@ -78,4 +79,18 @@ describe("DraftSelectionService", () => {
       expect(lastSelection.selection).toBeNull();
     });
   });
+
+  describe("finalizeOneForUser", () => {
+    it.each([...INVALID_NUMBER_CASES, ...NEGATIVE_NUMBER_CASES])("throws a ZodError if id provided is %p", async (id: unknown) => {
+      await expect(draftSelectionService.finalizeOneForUser(id as number, 1, { draftPokemonId: 1 })).rejects.toThrowError(ZodError)
+    })
+
+    it.each([...INVALID_NUMBER_CASES, ...NEGATIVE_NUMBER_CASES])("throws a ZodError if userId provided is %p", async (userId: unknown) => {
+      await expect(draftSelectionService.finalizeOneForUser(1, userId as number, { draftPokemonId: 1 })).rejects.toThrowError(ZodError)
+    })
+
+    it.each([...INVALID_NUMBER_CASES, ...NEGATIVE_NUMBER_CASES])("throws a ZodError if draftPokemonId provided is %p", async (draftPokemonId: unknown) => {
+      await expect(draftSelectionService.finalizeOneForUser(1, 1, { draftPokemonId: draftPokemonId as number })).rejects.toThrowError(ZodError)
+    })
+  })
 });

--- a/packages/back-end/src/draft-selection/draft-selection.service.spec.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.service.spec.ts
@@ -123,7 +123,7 @@ describe("DraftSelectionService", () => {
       const id = generateRandomNumber();
       const userId = generateRandomNumber();
       const request = generateMockFinalizeDraftSelectionRequest();
-      when(draftSelectionRepository.findOne(id)).thenResolve(undefined);
+      when(draftSelectionRepository.getPendingOneWithIdAndUserId(id, userId)).thenResolve(undefined);
       await expect(
         draftSelectionService.finalizeOneForUser(id, userId, request)
       ).rejects.toThrowError(NotFoundError);
@@ -134,11 +134,25 @@ describe("DraftSelectionService", () => {
       const userId = generateRandomNumber();
       const request = generateMockFinalizeDraftSelectionRequest();
       const draftSelectionEntity = generateMockDraftSelectionEntity()
-      when(draftSelectionRepository.findOne(id)).thenResolve(draftSelectionEntity);
+      when(draftSelectionRepository.getPendingOneWithIdAndUserId(id, userId)).thenResolve(draftSelectionEntity);
       when(draftSelectionRepository.getPendingSelectionsBeforeSelection(draftSelectionEntity)).thenResolve([generateMockDraftSelectionEntity()])
       await expect(
         draftSelectionService.finalizeOneForUser(id, userId, request)
       ).rejects.toThrowError(BadRequestError);
     });
+
+    it("returns a mapped DraftSelection if it was finalized", async () => {
+      const id = generateRandomNumber();
+      const userId = generateRandomNumber();
+      const request = generateMockFinalizeDraftSelectionRequest();
+      const draftSelectionEntity = generateMockDraftSelectionEntity()
+      when(draftSelectionRepository.getPendingOneWithIdAndUserId(id, userId)).thenResolve(draftSelectionEntity);
+      when(draftSelectionRepository.getPendingSelectionsBeforeSelection(draftSelectionEntity)).thenResolve([])
+      const expectedPokemon = generateMockPokemon()
+      when(pokemonService.getOneById(request.draftPokemonId)).thenResolve(expectedPokemon)
+      const finalizedSelection = await draftSelectionService.finalizeOneForUser(id, userId, request)
+      expect(finalizedSelection).toBeTruthy()
+      expect(finalizedSelection.selection).toEqual(expectedPokemon)
+    })
   });
 });

--- a/packages/back-end/src/draft-selection/draft-selection.service.spec.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.service.spec.ts
@@ -4,7 +4,10 @@ import { DraftSelectionService } from "./draft-selection.service";
 import { object, when } from "testdouble";
 import { DraftSelectionRepository } from "./draft-selection.repository";
 import { generateMockPokemon } from "../pokemon/pokemon.mock";
-import { generateMockDraftSelectionRow, generateMockFinalizeDraftSelectionRequest } from "./draft-selection.mock";
+import {
+  generateMockDraftSelectionRow,
+  generateMockFinalizeDraftSelectionRequest,
+} from "./draft-selection.mock";
 import { generateRandomNumber } from "../random";
 import { last } from "lodash";
 import { DraftSelection } from "./draft-selection";
@@ -82,24 +85,47 @@ describe("DraftSelectionService", () => {
   });
 
   describe("finalizeOneForUser", () => {
-    it.each([...INVALID_NUMBER_CASES, ...NEGATIVE_NUMBER_CASES])("throws a ZodError if id provided is %p", async (id: unknown) => {
-      await expect(draftSelectionService.finalizeOneForUser(id as number, 1, { draftPokemonId: 1 })).rejects.toThrowError(ZodError)
-    })
+    it.each([...INVALID_NUMBER_CASES, ...NEGATIVE_NUMBER_CASES])(
+      "throws a ZodError if id provided is %p",
+      async (id: unknown) => {
+        await expect(
+          draftSelectionService.finalizeOneForUser(id as number, 1, {
+            draftPokemonId: 1,
+          })
+        ).rejects.toThrowError(ZodError);
+      }
+    );
 
-    it.each([...INVALID_NUMBER_CASES, ...NEGATIVE_NUMBER_CASES])("throws a ZodError if userId provided is %p", async (userId: unknown) => {
-      await expect(draftSelectionService.finalizeOneForUser(1, userId as number, { draftPokemonId: 1 })).rejects.toThrowError(ZodError)
-    })
+    it.each([...INVALID_NUMBER_CASES, ...NEGATIVE_NUMBER_CASES])(
+      "throws a ZodError if userId provided is %p",
+      async (userId: unknown) => {
+        await expect(
+          draftSelectionService.finalizeOneForUser(1, userId as number, {
+            draftPokemonId: 1,
+          })
+        ).rejects.toThrowError(ZodError);
+      }
+    );
 
-    it.each([...INVALID_NUMBER_CASES, ...NEGATIVE_NUMBER_CASES])("throws a ZodError if draftPokemonId provided is %p", async (draftPokemonId: unknown) => {
-      await expect(draftSelectionService.finalizeOneForUser(1, 1, { draftPokemonId: draftPokemonId as number })).rejects.toThrowError(ZodError)
-    })
+    it.each([...INVALID_NUMBER_CASES, ...NEGATIVE_NUMBER_CASES])(
+      "throws a ZodError if draftPokemonId provided is %p",
+      async (draftPokemonId: unknown) => {
+        await expect(
+          draftSelectionService.finalizeOneForUser(1, 1, {
+            draftPokemonId: draftPokemonId as number,
+          })
+        ).rejects.toThrowError(ZodError);
+      }
+    );
 
     it("throws a NotFoundError if the information provided did not detect a draft selection", async () => {
-      const id = generateRandomNumber()
-      const userId = generateRandomNumber()
-      const request = generateMockFinalizeDraftSelectionRequest()
-      when(draftSelectionRepository.findOne(id)).thenResolve(undefined)
-      await expect(draftSelectionService.finalizeOneForUser(id, userId, request)).rejects.toThrowError(NotFoundError)
-    })
-  })
+      const id = generateRandomNumber();
+      const userId = generateRandomNumber();
+      const request = generateMockFinalizeDraftSelectionRequest();
+      when(draftSelectionRepository.findOne(id)).thenResolve(undefined);
+      await expect(
+        draftSelectionService.finalizeOneForUser(id, userId, request)
+      ).rejects.toThrowError(NotFoundError);
+    });
+  });
 });

--- a/packages/back-end/src/draft-selection/draft-selection.service.spec.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.service.spec.ts
@@ -123,7 +123,9 @@ describe("DraftSelectionService", () => {
       const id = generateRandomNumber();
       const userId = generateRandomNumber();
       const request = generateMockFinalizeDraftSelectionRequest();
-      when(draftSelectionRepository.getPendingOneWithIdAndUserId(id, userId)).thenResolve(undefined);
+      when(
+        draftSelectionRepository.getPendingOneWithIdAndUserId(id, userId)
+      ).thenResolve(undefined);
       await expect(
         draftSelectionService.finalizeOneForUser(id, userId, request)
       ).rejects.toThrowError(NotFoundError);
@@ -133,9 +135,15 @@ describe("DraftSelectionService", () => {
       const id = generateRandomNumber();
       const userId = generateRandomNumber();
       const request = generateMockFinalizeDraftSelectionRequest();
-      const draftSelectionEntity = generateMockDraftSelectionEntity()
-      when(draftSelectionRepository.getPendingOneWithIdAndUserId(id, userId)).thenResolve(draftSelectionEntity);
-      when(draftSelectionRepository.getPendingSelectionsBeforeSelection(draftSelectionEntity)).thenResolve([generateMockDraftSelectionEntity()])
+      const draftSelectionEntity = generateMockDraftSelectionEntity();
+      when(
+        draftSelectionRepository.getPendingOneWithIdAndUserId(id, userId)
+      ).thenResolve(draftSelectionEntity);
+      when(
+        draftSelectionRepository.getPendingSelectionsBeforeSelection(
+          draftSelectionEntity
+        )
+      ).thenResolve([generateMockDraftSelectionEntity()]);
       await expect(
         draftSelectionService.finalizeOneForUser(id, userId, request)
       ).rejects.toThrowError(BadRequestError);
@@ -145,14 +153,26 @@ describe("DraftSelectionService", () => {
       const id = generateRandomNumber();
       const userId = generateRandomNumber();
       const request = generateMockFinalizeDraftSelectionRequest();
-      const draftSelectionEntity = generateMockDraftSelectionEntity()
-      when(draftSelectionRepository.getPendingOneWithIdAndUserId(id, userId)).thenResolve(draftSelectionEntity);
-      when(draftSelectionRepository.getPendingSelectionsBeforeSelection(draftSelectionEntity)).thenResolve([])
-      const expectedPokemon = generateMockPokemon()
-      when(pokemonService.getOneById(request.draftPokemonId)).thenResolve(expectedPokemon)
-      const finalizedSelection = await draftSelectionService.finalizeOneForUser(id, userId, request)
-      expect(finalizedSelection).toBeTruthy()
-      expect(finalizedSelection.selection).toEqual(expectedPokemon)
-    })
+      const draftSelectionEntity = generateMockDraftSelectionEntity();
+      when(
+        draftSelectionRepository.getPendingOneWithIdAndUserId(id, userId)
+      ).thenResolve(draftSelectionEntity);
+      when(
+        draftSelectionRepository.getPendingSelectionsBeforeSelection(
+          draftSelectionEntity
+        )
+      ).thenResolve([]);
+      const expectedPokemon = generateMockPokemon();
+      when(pokemonService.getOneById(request.draftPokemonId)).thenResolve(
+        expectedPokemon
+      );
+      const finalizedSelection = await draftSelectionService.finalizeOneForUser(
+        id,
+        userId,
+        request
+      );
+      expect(finalizedSelection).toBeTruthy();
+      expect(finalizedSelection.selection).toEqual(expectedPokemon);
+    });
   });
 });

--- a/packages/back-end/src/draft-selection/draft-selection.service.spec.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.service.spec.ts
@@ -4,11 +4,12 @@ import { DraftSelectionService } from "./draft-selection.service";
 import { object, when } from "testdouble";
 import { DraftSelectionRepository } from "./draft-selection.repository";
 import { generateMockPokemon } from "../pokemon/pokemon.mock";
-import { generateMockDraftSelectionRow } from "./draft-selection.mock";
+import { generateMockDraftSelectionRow, generateMockFinalizeDraftSelectionRequest } from "./draft-selection.mock";
 import { generateRandomNumber } from "../random";
 import { last } from "lodash";
 import { DraftSelection } from "./draft-selection";
 import { INVALID_NUMBER_CASES, NEGATIVE_NUMBER_CASES } from "../test/cases";
+import { NotFoundError } from "../error";
 
 describe("DraftSelectionService", () => {
   let draftSelectionService: DraftSelectionService;
@@ -91,6 +92,14 @@ describe("DraftSelectionService", () => {
 
     it.each([...INVALID_NUMBER_CASES, ...NEGATIVE_NUMBER_CASES])("throws a ZodError if draftPokemonId provided is %p", async (draftPokemonId: unknown) => {
       await expect(draftSelectionService.finalizeOneForUser(1, 1, { draftPokemonId: draftPokemonId as number })).rejects.toThrowError(ZodError)
+    })
+
+    it("throws a NotFoundError if the information provided did not detect a draft selection", async () => {
+      const id = generateRandomNumber()
+      const userId = generateRandomNumber()
+      const request = generateMockFinalizeDraftSelectionRequest()
+      when(draftSelectionRepository.findOne(id)).thenResolve(undefined)
+      await expect(draftSelectionService.finalizeOneForUser(id, userId, request)).rejects.toThrowError(NotFoundError)
     })
   })
 });

--- a/packages/back-end/src/draft-selection/draft-selection.service.spec.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.service.spec.ts
@@ -5,6 +5,7 @@ import { object, when } from "testdouble";
 import { DraftSelectionRepository } from "./draft-selection.repository";
 import { generateMockPokemon } from "../pokemon/pokemon.mock";
 import {
+  generateMockDraftSelectionEntity,
   generateMockDraftSelectionRow,
   generateMockFinalizeDraftSelectionRequest,
 } from "./draft-selection.mock";
@@ -12,7 +13,7 @@ import { generateRandomNumber } from "../random";
 import { last } from "lodash";
 import { DraftSelection } from "./draft-selection";
 import { INVALID_NUMBER_CASES, NEGATIVE_NUMBER_CASES } from "../test/cases";
-import { NotFoundError } from "../error";
+import { BadRequestError, NotFoundError } from "../error";
 
 describe("DraftSelectionService", () => {
   let draftSelectionService: DraftSelectionService;
@@ -126,6 +127,18 @@ describe("DraftSelectionService", () => {
       await expect(
         draftSelectionService.finalizeOneForUser(id, userId, request)
       ).rejects.toThrowError(NotFoundError);
+    });
+
+    it("throws a BadRequestError if the pick is not ready to be finalized", async () => {
+      const id = generateRandomNumber();
+      const userId = generateRandomNumber();
+      const request = generateMockFinalizeDraftSelectionRequest();
+      const draftSelectionEntity = generateMockDraftSelectionEntity()
+      when(draftSelectionRepository.findOne(id)).thenResolve(draftSelectionEntity);
+      when(draftSelectionRepository.getPendingSelectionsBeforeSelection(draftSelectionEntity)).thenResolve([generateMockDraftSelectionEntity()])
+      await expect(
+        draftSelectionService.finalizeOneForUser(id, userId, request)
+      ).rejects.toThrowError(BadRequestError);
     });
   });
 });

--- a/packages/back-end/src/draft-selection/draft-selection.service.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.service.ts
@@ -41,6 +41,11 @@ export class DraftSelectionService {
         `Could not find draft selection with id = ${id} for user = ${userId}`
       );
     }
+
+    const priorPendingSelections = await this.draftSelectionRepository.getPendingSelectionsBeforeSelection(draftSelection)
+    if (priorPendingSelections.length) {
+    }
+
     await this.draftSelectionRepository.update(
       { pokemonId: request.draftPokemonId },
       draftSelection

--- a/packages/back-end/src/draft-selection/draft-selection.service.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.service.ts
@@ -36,21 +36,30 @@ export class DraftSelectionService {
     z.number().positive().parse(userId);
     finalizeDraftSelectionRequestSchema.parse(request);
 
-    const draftSelection = await this.draftSelectionRepository.getPendingOneWithIdAndUserId(id, userId);
+    const draftSelection =
+      await this.draftSelectionRepository.getPendingOneWithIdAndUserId(
+        id,
+        userId
+      );
     if (!draftSelection) {
       throw new NotFoundError(
         `Could not find draft selection with id = ${id} for user = ${userId}`
       );
     }
 
-    const priorPendingSelections = await this.draftSelectionRepository.getPendingSelectionsBeforeSelection(draftSelection)
+    const priorPendingSelections =
+      await this.draftSelectionRepository.getPendingSelectionsBeforeSelection(
+        draftSelection
+      );
     if (priorPendingSelections.length) {
-      throw new BadRequestError("The Draft Selection is not ready to be finalized yet. There are still pending picks before this one.")
+      throw new BadRequestError(
+        "The Draft Selection is not ready to be finalized yet. There are still pending picks before this one."
+      );
     }
 
-    draftSelection.pokemonId = request.draftPokemonId
-    await this.draftSelectionRepository.save(draftSelection)
-    return this.mapEntityToDto(draftSelection)
+    draftSelection.pokemonId = request.draftPokemonId;
+    await this.draftSelectionRepository.save(draftSelection);
+    return this.mapEntityToDto(draftSelection);
   }
 
   private async mapRowToDto(row: DraftSelectionRow): Promise<DraftSelection> {
@@ -60,16 +69,18 @@ export class DraftSelectionService {
     };
   }
 
-  private async mapEntityToDto(entity: DraftSelectionEntity): Promise<DraftSelection> {
-    const participant = await entity.challengeParticipant
-    const user = await participant.user
+  private async mapEntityToDto(
+    entity: DraftSelectionEntity
+  ): Promise<DraftSelection> {
+    const participant = await entity.challengeParticipant;
+    const user = await participant.user;
     return {
       id: entity.id,
       round: entity.roundNumber,
       pick: entity.pickNumber,
       selection: await this.getPokemonForDraftSelection(entity),
       userNickname: user.nickname,
-      userId: user.id
+      userId: user.id,
     };
   }
 

--- a/packages/back-end/src/draft-selection/draft-selection.service.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.service.ts
@@ -34,6 +34,7 @@ export class DraftSelectionService {
     if (!draftSelection) {
       throw new NotFoundError(`Could not find draft selection with id = ${id} for user = ${userId}`)
     }
+    await this.draftSelectionRepository.update({ pokemonId: request.draftPokemonId }, draftSelection)
   }
 
   private async mapRowToDto (row: DraftSelectionRow): Promise<DraftSelection> {

--- a/packages/back-end/src/draft-selection/draft-selection.service.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.service.ts
@@ -2,7 +2,10 @@ import { DraftSelection, DraftSelectionRow } from "./draft-selection";
 import { z } from "zod";
 import { Pokemon, PokemonService } from "../pokemon";
 import { DraftSelectionRepository } from "./draft-selection.repository";
-import { FinalizeDraftSelectionRequest, finalizeDraftSelectionRequestSchema } from "./finalize-draft-selection-request";
+import {
+  FinalizeDraftSelectionRequest,
+  finalizeDraftSelectionRequestSchema,
+} from "./finalize-draft-selection-request";
 import { NotFoundError } from "../error";
 
 export class DraftSelectionService {
@@ -17,7 +20,9 @@ export class DraftSelectionService {
     const foundSelections =
       await this.draftSelectionRepository.getAllForDraftId(draftId);
     return Promise.all(
-      foundSelections.map(async (foundSelection) => this.mapRowToDto(foundSelection))
+      foundSelections.map(async (foundSelection) =>
+        this.mapRowToDto(foundSelection)
+      )
     );
   }
 
@@ -26,22 +31,27 @@ export class DraftSelectionService {
     userId: number,
     request: FinalizeDraftSelectionRequest
   ): Promise<void> {
-    z.number().positive().parse(id)
-    z.number().positive().parse(userId)
-    finalizeDraftSelectionRequestSchema.parse(request)
+    z.number().positive().parse(id);
+    z.number().positive().parse(userId);
+    finalizeDraftSelectionRequestSchema.parse(request);
 
-    const draftSelection = await this.draftSelectionRepository.findOne(id)
+    const draftSelection = await this.draftSelectionRepository.findOne(id);
     if (!draftSelection) {
-      throw new NotFoundError(`Could not find draft selection with id = ${id} for user = ${userId}`)
+      throw new NotFoundError(
+        `Could not find draft selection with id = ${id} for user = ${userId}`
+      );
     }
-    await this.draftSelectionRepository.update({ pokemonId: request.draftPokemonId }, draftSelection)
+    await this.draftSelectionRepository.update(
+      { pokemonId: request.draftPokemonId },
+      draftSelection
+    );
   }
 
-  private async mapRowToDto (row: DraftSelectionRow): Promise<DraftSelection> {
+  private async mapRowToDto(row: DraftSelectionRow): Promise<DraftSelection> {
     return {
       ...row,
       selection: await this.getPokemonForDraftSelection(row),
-    }
+    };
   }
 
   private async getPokemonForDraftSelection(

--- a/packages/back-end/src/draft-selection/draft-selection.service.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.service.ts
@@ -6,7 +6,7 @@ import {
   FinalizeDraftSelectionRequest,
   finalizeDraftSelectionRequestSchema,
 } from "./finalize-draft-selection-request";
-import { NotFoundError } from "../error";
+import { BadRequestError, NotFoundError } from "../error";
 
 export class DraftSelectionService {
   constructor(
@@ -44,6 +44,7 @@ export class DraftSelectionService {
 
     const priorPendingSelections = await this.draftSelectionRepository.getPendingSelectionsBeforeSelection(draftSelection)
     if (priorPendingSelections.length) {
+      throw new BadRequestError("The Draft Selection is not ready to be finalized yet. There are still pending picks before this one.")
     }
 
     await this.draftSelectionRepository.update(

--- a/packages/back-end/src/draft-selection/draft-selection.ts
+++ b/packages/back-end/src/draft-selection/draft-selection.ts
@@ -1,17 +1,17 @@
 import { Pokemon } from "../pokemon";
 
-export interface DraftSelectionRow {
+interface SharedDraftSelectionCriteria {
   readonly id: number;
   readonly round: number;
   readonly pick: number;
   readonly userNickname: string;
+  readonly userId: number;
+}
+
+export interface DraftSelectionRow extends SharedDraftSelectionCriteria {
   readonly pokemonId: number | null;
 }
 
-export interface DraftSelection {
-  readonly id: number;
-  readonly round: number;
-  readonly pick: number;
-  readonly userNickname: string;
+export interface DraftSelection extends SharedDraftSelectionCriteria {
   readonly selection: Pokemon | null;
 }

--- a/packages/back-end/src/draft-selection/finalize-draft-selection-request.ts
+++ b/packages/back-end/src/draft-selection/finalize-draft-selection-request.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
 
 export const finalizeDraftSelectionRequestSchema = z.object({
-  draftPokemonId: z.number().positive()
-})
+  draftPokemonId: z.number().positive(),
+});
 
-export type FinalizeDraftSelectionRequest = z.infer<typeof finalizeDraftSelectionRequestSchema>
+export type FinalizeDraftSelectionRequest = z.infer<
+  typeof finalizeDraftSelectionRequestSchema
+>;

--- a/packages/back-end/src/draft-selection/finalize-draft-selection-request.ts
+++ b/packages/back-end/src/draft-selection/finalize-draft-selection-request.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const finalizeDraftSelectionRequestSchema = z.object({
+  draftPokemonId: z.number().positive()
+})
+
+export type FinalizeDraftSelectionRequest = z.infer<typeof finalizeDraftSelectionRequestSchema>

--- a/packages/back-end/src/draft/draft.entity.ts
+++ b/packages/back-end/src/draft/draft.entity.ts
@@ -7,6 +7,7 @@ import {
   PrimaryGeneratedColumn,
 } from "typeorm";
 import { ChallengeEntity } from "../challenge/challenge.entity";
+import { DraftSelectionEntity } from "../draft-selection";
 import { DraftPokemonEntity } from "./draft-pokemon.entity";
 
 @Entity({
@@ -30,4 +31,7 @@ export class DraftEntity {
 
   @Column()
   livePoolPokemonIndex!: number;
+
+  @OneToMany(() => DraftSelectionEntity, (draftSelection) => draftSelection.draft)
+  selections!: Promise<DraftSelectionEntity[]>;
 }

--- a/packages/back-end/src/draft/draft.entity.ts
+++ b/packages/back-end/src/draft/draft.entity.ts
@@ -32,6 +32,9 @@ export class DraftEntity {
   @Column()
   livePoolPokemonIndex!: number;
 
-  @OneToMany(() => DraftSelectionEntity, (draftSelection) => draftSelection.draft)
+  @OneToMany(
+    () => DraftSelectionEntity,
+    (draftSelection) => draftSelection.draft
+  )
   selections!: Promise<DraftSelectionEntity[]>;
 }

--- a/packages/back-end/src/draft/draft.service.int.spec.ts
+++ b/packages/back-end/src/draft/draft.service.int.spec.ts
@@ -39,7 +39,7 @@ describe("DraftService (integration)", () => {
       expect(draftGotten.livePoolingHasFinished).toEqual(false);
     });
 
-    it("returns that draft has finished live pooling if it did", async () => {
+    it("returns that the draft has finished live pooling if it did", async () => {
       let draft = (await draftRepository.findOne(2)) as DraftEntity;
       const challenge = (await challengeRepository.findOne(
         2

--- a/packages/back-end/src/error/bad-request-error.ts
+++ b/packages/back-end/src/error/bad-request-error.ts
@@ -1,0 +1,8 @@
+export class BadRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+
+    // Set the prototype explicitly.
+    Object.setPrototypeOf(this, BadRequestError.prototype);
+  }
+}

--- a/packages/back-end/src/error/error.middleware.spec.ts
+++ b/packages/back-end/src/error/error.middleware.spec.ts
@@ -10,7 +10,7 @@ import { Context } from "koa";
 import { object } from "testdouble";
 import { errorMiddleware } from "./error.middleware";
 import { z } from "zod";
-import { NotFoundError, UnauthorizedError, ForbiddenError } from ".";
+import { NotFoundError, UnauthorizedError, ForbiddenError, BadRequestError } from ".";
 
 describe("errorMiddleware", () => {
   it("does nothing if next is successful", async () => {
@@ -71,6 +71,16 @@ describe("errorMiddleware", () => {
     expect(next).toHaveBeenCalled();
     expect(ctx.status).toEqual(FORBIDDEN);
   });
+
+  it("handles a BadRequestError correctly", async () => {
+    const ctx = object<Context>();
+    ctx.status = OK;
+    const error = new BadRequestError("Expected Test Error");
+    const next = jest.fn().mockRejectedValue(error);
+    await errorMiddleware(ctx, next);
+    expect(next).toHaveBeenCalled();
+    expect(ctx.status).toEqual(BAD_REQUEST);
+  })
 
   it("handles a unhandled errors correctly", async () => {
     const ctx = object<Context>();

--- a/packages/back-end/src/error/error.middleware.spec.ts
+++ b/packages/back-end/src/error/error.middleware.spec.ts
@@ -10,7 +10,12 @@ import { Context } from "koa";
 import { object } from "testdouble";
 import { errorMiddleware } from "./error.middleware";
 import { z } from "zod";
-import { NotFoundError, UnauthorizedError, ForbiddenError, BadRequestError } from ".";
+import {
+  NotFoundError,
+  UnauthorizedError,
+  ForbiddenError,
+  BadRequestError,
+} from ".";
 
 describe("errorMiddleware", () => {
   it("does nothing if next is successful", async () => {
@@ -80,7 +85,7 @@ describe("errorMiddleware", () => {
     await errorMiddleware(ctx, next);
     expect(next).toHaveBeenCalled();
     expect(ctx.status).toEqual(BAD_REQUEST);
-  })
+  });
 
   it("handles a unhandled errors correctly", async () => {
     const ctx = object<Context>();

--- a/packages/back-end/src/error/error.middleware.ts
+++ b/packages/back-end/src/error/error.middleware.ts
@@ -8,6 +8,7 @@ import {
 import { Context, Next } from "koa";
 import { z } from "zod";
 import { NotFoundError, UnauthorizedError, ForbiddenError } from ".";
+import { BadRequestError } from "./bad-request-error";
 
 export const errorMiddleware = async (
   ctx: Context,
@@ -16,7 +17,7 @@ export const errorMiddleware = async (
   try {
     await next();
   } catch (error) {
-    if (error instanceof z.ZodError) {
+    if (error instanceof z.ZodError || error instanceof BadRequestError) {
       ctx.body = error.message;
       ctx.status = BAD_REQUEST;
     } else if (error instanceof NotFoundError) {

--- a/packages/back-end/src/error/index.ts
+++ b/packages/back-end/src/error/index.ts
@@ -2,3 +2,4 @@ export * from "./error.middleware";
 export * from "./not-found-error";
 export * from "./unauthorized-error";
 export * from "./forbidden-error";
+export * from "./bad-request-error";

--- a/packages/back-end/src/test/cases.ts
+++ b/packages/back-end/src/test/cases.ts
@@ -1,1 +1,2 @@
 export const INVALID_NUMBER_CASES = [undefined, null, "", "1", NaN];
+export const NEGATIVE_NUMBER_CASES = [-1, -10, -100];

--- a/packages/back-end/src/test/create-db-connection.ts
+++ b/packages/back-end/src/test/create-db-connection.ts
@@ -22,9 +22,9 @@ export const establishDbConnection = async (): Promise<Connection> => {
     });
   }
 
-  const queryRunner = connection.createQueryRunner()
-  await queryRunner.dropDatabase("pokemon-league", true)
-  await queryRunner.createDatabase("pokemon-league", true)
+  const queryRunner = connection.createQueryRunner();
+  await queryRunner.dropDatabase("pokemon-league", true);
+  await queryRunner.createDatabase("pokemon-league", true);
   await connection.runMigrations();
   return connection;
 };

--- a/packages/back-end/src/test/create-db-connection.ts
+++ b/packages/back-end/src/test/create-db-connection.ts
@@ -20,7 +20,11 @@ export const establishDbConnection = async (): Promise<Connection> => {
       connectTimeoutMS: 20000,
       namingStrategy: new SnakeNamingStrategy(),
     });
-    await connection.runMigrations();
   }
+
+  const queryRunner = connection.createQueryRunner()
+  await queryRunner.dropDatabase("pokemon-league", true)
+  await queryRunner.createDatabase("pokemon-league", true)
+  await connection.runMigrations();
   return connection;
 };


### PR DESCRIPTION
Creates the business logic around selecting a Pokemon in a draft, along with some validation to ensure bad actors can't spoof other user's draft picks and also ensuring that previous picks in a draft must be made for the draft selection to be finalized.